### PR TITLE
Fix dashboard header user email display

### DIFF
--- a/frontend/src/hooks/useLogout.test.tsx
+++ b/frontend/src/hooks/useLogout.test.tsx
@@ -52,6 +52,7 @@ describe('useLogout', () => {
     });
     expect(localStorage.getItem('token')).toBeNull();
     expect(localStorage.getItem('refresh_token')).toBeNull();
+    expect(localStorage.getItem('user_email')).toBeNull();
     expect(mockNavigate).toHaveBeenCalledWith('/login');
   });
 
@@ -68,6 +69,7 @@ describe('useLogout', () => {
     });
     expect(localStorage.getItem('token')).toBeNull();
     expect(localStorage.getItem('refresh_token')).toBeNull();
+    expect(localStorage.getItem('user_email')).toBeNull();
   });
 
   it('skips logout API when refresh token missing, but still clears and redirects', async () => {
@@ -82,5 +84,6 @@ describe('useLogout', () => {
     expect(authApi.logout).not.toHaveBeenCalled();
     expect(localStorage.getItem('token')).toBeNull();
     expect(localStorage.getItem('refresh_token')).toBeNull();
+    expect(localStorage.getItem('user_email')).toBeNull();
   });
 });

--- a/frontend/src/hooks/useLogout.ts
+++ b/frontend/src/hooks/useLogout.ts
@@ -15,6 +15,7 @@ export function useLogout() {
     } finally {
       localStorage.removeItem('token');
       localStorage.removeItem('refresh_token');
+      localStorage.removeItem('user_email');
       navigate('/login');
     }
   };

--- a/frontend/src/pages/Login.test.tsx
+++ b/frontend/src/pages/Login.test.tsx
@@ -58,6 +58,7 @@ describe('Login page', () => {
       expect(localStorage.getItem('token')).toBe('access-token');
     });
     expect(localStorage.getItem('refresh_token')).toBe('refresh-token');
+    expect(localStorage.getItem('user_email')).toBe('user@example.com');
     expect(authApi.login).toHaveBeenCalledWith({
       email: 'user@example.com',
       password: 'secret123',

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -23,6 +23,7 @@ export default function Login() {
       });
       localStorage.setItem('token', response.data.access_token);
       localStorage.setItem('refresh_token', response.data.refresh_token);
+      localStorage.setItem('user_email', response.data.user.email);
       navigate('/dashboard');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Login failed');


### PR DESCRIPTION
## Summary
Fix the issue where the Dashboard header never displays the user email.

## Changes
- Save `user_email` to `localStorage` on login
- Clear `user_email` on logout
- Update login/logout tests to cover the behavior

Fixes #3
