### PR TITLE
Story 2.1: Project list & create (projects API + UI)

### DIFF
--- a/_bmad-output/implementation-artifacts/2-1-project-list-create.md
+++ b/_bmad-output/implementation-artifacts/2-1-project-list-create.md
@@ -1,0 +1,294 @@
+# Story 2.1: Project List & Create
+
+Status: ready-for-dev
+
+## Story
+
+As a **user**,
+I want to **view my projects and create new ones**,
+So that **I can organize my work**.
+
+## Acceptance Criteria
+
+1. **Given** I am logged in **When** I navigate to the projects page **Then** I see a list of my projects
+2. **Given** I am logged in **When** I create a new project by entering a name **Then** the project is created and appears in my list
+3. **Given** I am logged in **Then** only my own projects are visible (not other users')
+4. **Given** I am not authenticated **When** I try to access /projects or the API **Then** I am redirected/receive 401
+5. **Given** I submit an empty project name **Then** I see a validation error
+6. **Given** I have no projects **Then** I see an empty state message
+
+## Tasks / Subtasks
+
+- [ ] **Task 1: Project Database Model** (AC: 1, 2, 3)
+  - [ ] Create `backend/app/models/project.py` with Project model
+  - [ ] Add fields: id, name, user_id (FK), created_at, updated_at
+  - [ ] Add relationship to User model
+  - [ ] Export from `backend/app/models/__init__.py`
+  - [ ] Create projects table (manual migration or auto-create)
+
+- [ ] **Task 2: Project Schemas** (AC: 2, 5)
+  - [ ] Create `backend/app/schemas/project.py`
+  - [ ] Add `ProjectCreate` schema (name: str, min_length=1)
+  - [ ] Add `ProjectResponse` schema (id, name, user_id, created_at, updated_at)
+  - [ ] Add `ProjectListResponse` schema for list endpoint
+  - [ ] Export from `backend/app/schemas/__init__.py`
+
+- [ ] **Task 3: Projects API Router** (AC: 1, 2, 3, 4)
+  - [ ] Create `backend/app/routers/projects.py`
+  - [ ] Implement `GET /api/projects` - list current user's projects
+  - [ ] Implement `POST /api/projects` - create new project for current user
+  - [ ] Use `get_current_user` dependency for authentication
+  - [ ] Filter projects by current user's id
+  - [ ] Register router in `backend/app/main.py`
+
+- [ ] **Task 4: Backend Testing** (AC: 1, 2, 3, 4, 5)
+  - [ ] Create `backend/tests/api/test_projects_api.py`
+  - [ ] Test: GET /projects returns empty list for new user
+  - [ ] Test: POST /projects creates project and returns it
+  - [ ] Test: GET /projects returns only user's own projects
+  - [ ] Test: POST /projects with empty name returns 422
+  - [ ] Test: Unauthenticated requests return 401
+
+- [ ] **Task 5: Frontend API Client** (AC: 1, 2)
+  - [ ] Add `ProjectData` interface to `frontend/src/api/client.ts`
+  - [ ] Add `projectsApi` object with `list()` and `create()` methods
+  - [ ] Follow existing authApi pattern
+
+- [ ] **Task 6: Projects Page UI** (AC: 1, 2, 5, 6)
+  - [ ] Create `frontend/src/pages/Projects.tsx`
+  - [ ] Display list of projects (name, created date)
+  - [ ] Add "Create Project" form with name input
+  - [ ] Show loading state while fetching
+  - [ ] Show empty state when no projects exist
+  - [ ] Show validation error for empty name
+  - [ ] Style with Tailwind CSS matching existing design
+
+- [ ] **Task 7: Update App Routing** (AC: 1, 4)
+  - [ ] Add `/projects` route to `frontend/src/App.tsx`
+  - [ ] Wrap with ProtectedRoute
+  - [ ] Update Dashboard to link to Projects page (or make Projects the new dashboard)
+
+- [ ] **Task 8: Frontend Testing** (AC: 1, 2, 5, 6)
+  - [ ] Create `frontend/src/pages/Projects.test.tsx`
+  - [ ] Test: Projects page renders project list
+  - [ ] Test: Create form submits and adds project to list
+  - [ ] Test: Empty name shows validation error
+  - [ ] Test: Empty state displays when no projects
+
+## Dev Notes
+
+### Architecture Compliance
+
+**Backend Structure:**
+- Model: `backend/app/models/project.py`
+- Schema: `backend/app/schemas/project.py`
+- Router: `backend/app/routers/projects.py`
+- Tests: `backend/tests/api/test_projects_api.py`
+
+**Frontend Structure:**
+- Page: `frontend/src/pages/Projects.tsx`
+- API: Add to `frontend/src/api/client.ts`
+- Route: Add to `frontend/src/App.tsx`
+
+**Database:** SQLite (dev) / PostgreSQL (prod) via SQLAlchemy
+
+### Technical Requirements
+
+| Requirement | Implementation |
+|-------------|----------------|
+| Authentication | `get_current_user` dependency from Epic 1 |
+| User isolation | Filter by `user_id = current_user.id` |
+| Validation | Pydantic schemas with min_length |
+| API format | `{ "data": [...] }` wrapper |
+| Frontend state | useState for projects list |
+
+### Database Schema
+
+**projects table:**
+```sql
+CREATE TABLE projects (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name VARCHAR NOT NULL,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX ix_projects_user_id ON projects(user_id);
+```
+
+### API Endpoint Specs
+
+**GET /api/projects** (Protected)
+
+Request Headers:
+```
+Authorization: Bearer <access_token>
+```
+
+Success Response (200):
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "name": "My Project",
+      "user_id": 1,
+      "created_at": "2026-01-21T00:00:00Z",
+      "updated_at": "2026-01-21T00:00:00Z"
+    }
+  ]
+}
+```
+
+---
+
+**POST /api/projects** (Protected)
+
+Request:
+```json
+{
+  "name": "New Project"
+}
+```
+
+Success Response (201):
+```json
+{
+  "data": {
+    "id": 2,
+    "name": "New Project",
+    "user_id": 1,
+    "created_at": "2026-01-21T00:00:00Z",
+    "updated_at": "2026-01-21T00:00:00Z"
+  }
+}
+```
+
+Validation Error (422):
+```json
+{
+  "detail": [
+    {
+      "loc": ["body", "name"],
+      "msg": "String should have at least 1 character",
+      "type": "string_too_short"
+    }
+  ]
+}
+```
+
+### Component Specifications
+
+**Project Model:**
+```python
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from sqlalchemy.orm import relationship
+from datetime import datetime, timezone
+
+class Project(Base):
+    __tablename__ = "projects"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+
+    owner = relationship("User", back_populates="projects")
+```
+
+**Projects Router Pattern:**
+```python
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+from ..database import get_db
+from ..utils.auth import get_current_user
+from ..models.user import User
+from ..models.project import Project
+from ..schemas.project import ProjectCreate, ProjectResponse
+
+router = APIRouter(prefix="/projects", tags=["projects"])
+
+@router.get("", response_model=dict)
+def list_projects(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    projects = db.query(Project).filter(Project.user_id == current_user.id).all()
+    return {"data": projects}
+
+@router.post("", response_model=dict, status_code=status.HTTP_201_CREATED)
+def create_project(
+    project_data: ProjectCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    project = Project(name=project_data.name, user_id=current_user.id)
+    db.add(project)
+    db.commit()
+    db.refresh(project)
+    return {"data": project}
+```
+
+**Frontend projectsApi:**
+```typescript
+export interface ProjectData {
+  id: number;
+  name: string;
+  user_id: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateProjectData {
+  name: string;
+}
+
+export const projectsApi = {
+  list: () => api.get<ApiResponse<ProjectData[]>>('/projects'),
+  create: (data: CreateProjectData) =>
+    api.post<ApiResponse<ProjectData>>('/projects', data),
+};
+```
+
+### References
+
+**Planning Documents:**
+- [PRD: FR5, FR6](../planning-artifacts/prd.md)
+- [Architecture: Project Structure](../planning-artifacts/architecture.md)
+- [Epics: Story 2.1](../planning-artifacts/epics.md#Story-2.1-Project-List--Create)
+
+**Source: Epic 1 Patterns**
+- [backend/app/utils/auth.py](../../backend/app/utils/auth.py) - get_current_user dependency
+- [backend/app/models/user.py](../../backend/app/models/user.py) - Model pattern
+- [backend/app/routers/auth.py](../../backend/app/routers/auth.py) - Router pattern
+- [frontend/src/api/client.ts](../../frontend/src/api/client.ts) - API client pattern
+- [frontend/src/pages/Login.tsx](../../frontend/src/pages/Login.tsx) - Page/form pattern
+
+## Dev Agent Record
+
+### Agent Model Used
+
+(To be filled by dev agent)
+
+### Completion Notes List
+
+(To be filled by dev agent)
+
+### File List
+
+**To Create:**
+- backend/app/models/project.py
+- backend/app/schemas/project.py
+- backend/app/routers/projects.py
+- backend/tests/api/test_projects_api.py
+- frontend/src/pages/Projects.tsx
+- frontend/src/pages/Projects.test.tsx
+
+**To Modify:**
+- backend/app/models/__init__.py (export Project)
+- backend/app/schemas/__init__.py (export project schemas)
+- backend/app/main.py (register projects router)
+- backend/app/models/user.py (add projects relationship - optional)
+- frontend/src/api/client.ts (add projectsApi)
+- frontend/src/App.tsx (add /projects route)

--- a/_bmad-output/implementation-artifacts/2-1-project-list-create.md
+++ b/_bmad-output/implementation-artifacts/2-1-project-list-create.md
@@ -1,6 +1,6 @@
 # Story 2.1: Project List & Create
 
-Status: review
+Status: done
 
 ## Story
 
@@ -276,7 +276,11 @@ GPT-5 (Codex CLI)
 - Added Project model, schemas, and projects router with authenticated list/create endpoints.
 - Implemented Projects page UI, API client, and routing from Dashboard.
 - Added backend API coverage plus frontend Projects page tests and updated Dashboard tests.
+- Hardened project name validation against whitespace-only values and added coverage.
+- Redirects unauthorized project list/create responses via logout handler.
+- Projects endpoints use async handlers with threadpool for DB I/O.
 - Tests: `python -m unittest backend.tests.unit.test_project_model`, `python -m unittest backend.tests.unit.test_project_schema`, `python -m unittest backend.tests.unit.test_projects_router`, `python -m unittest backend.tests.api.test_projects_api`, `npm test` (frontend), `scripts/windows/run-backend-tests.bat`, `scripts/windows/run-frontend-tests.bat`.
+  - Additional: `python -m unittest backend.tests.unit.test_project_schema` (post-review fix).
 
 ### File List
 
@@ -296,9 +300,14 @@ GPT-5 (Codex CLI)
 - backend/app/models/__init__.py
 - backend/app/models/user.py
 - backend/app/routers/__init__.py
+- backend/app/routers/projects.py
 - backend/app/schemas/__init__.py
+- backend/app/schemas/project.py
+- backend/tests/unit/test_project_schema.py
 - frontend/src/App.tsx
 - frontend/src/api/client.ts
 - frontend/src/components/Header.test.tsx
 - frontend/src/pages/Dashboard.test.tsx
 - frontend/src/pages/Dashboard.tsx
+- frontend/src/pages/Projects.test.tsx
+- frontend/src/pages/Projects.tsx

--- a/_bmad-output/implementation-artifacts/2-1-project-list-create.md
+++ b/_bmad-output/implementation-artifacts/2-1-project-list-create.md
@@ -1,6 +1,6 @@
 # Story 2.1: Project List & Create
 
-Status: ready-for-dev
+Status: review
 
 ## Story
 
@@ -19,61 +19,61 @@ So that **I can organize my work**.
 
 ## Tasks / Subtasks
 
-- [ ] **Task 1: Project Database Model** (AC: 1, 2, 3)
-  - [ ] Create `backend/app/models/project.py` with Project model
-  - [ ] Add fields: id, name, user_id (FK), created_at, updated_at
-  - [ ] Add relationship to User model
-  - [ ] Export from `backend/app/models/__init__.py`
-  - [ ] Create projects table (manual migration or auto-create)
+- [x] **Task 1: Project Database Model** (AC: 1, 2, 3)
+  - [x] Create `backend/app/models/project.py` with Project model
+  - [x] Add fields: id, name, user_id (FK), created_at, updated_at
+  - [x] Add relationship to User model
+  - [x] Export from `backend/app/models/__init__.py`
+  - [x] Create projects table (manual migration or auto-create)
 
-- [ ] **Task 2: Project Schemas** (AC: 2, 5)
-  - [ ] Create `backend/app/schemas/project.py`
-  - [ ] Add `ProjectCreate` schema (name: str, min_length=1)
-  - [ ] Add `ProjectResponse` schema (id, name, user_id, created_at, updated_at)
-  - [ ] Add `ProjectListResponse` schema for list endpoint
-  - [ ] Export from `backend/app/schemas/__init__.py`
+- [x] **Task 2: Project Schemas** (AC: 2, 5)
+  - [x] Create `backend/app/schemas/project.py`
+  - [x] Add `ProjectCreate` schema (name: str, min_length=1)
+  - [x] Add `ProjectResponse` schema (id, name, user_id, created_at, updated_at)
+  - [x] Add `ProjectListResponse` schema for list endpoint
+  - [x] Export from `backend/app/schemas/__init__.py`
 
-- [ ] **Task 3: Projects API Router** (AC: 1, 2, 3, 4)
-  - [ ] Create `backend/app/routers/projects.py`
-  - [ ] Implement `GET /api/projects` - list current user's projects
-  - [ ] Implement `POST /api/projects` - create new project for current user
-  - [ ] Use `get_current_user` dependency for authentication
-  - [ ] Filter projects by current user's id
-  - [ ] Register router in `backend/app/main.py`
+- [x] **Task 3: Projects API Router** (AC: 1, 2, 3, 4)
+  - [x] Create `backend/app/routers/projects.py`
+  - [x] Implement `GET /api/projects` - list current user's projects
+  - [x] Implement `POST /api/projects` - create new project for current user
+  - [x] Use `get_current_user` dependency for authentication
+  - [x] Filter projects by current user's id
+  - [x] Register router in `backend/app/main.py`
 
-- [ ] **Task 4: Backend Testing** (AC: 1, 2, 3, 4, 5)
-  - [ ] Create `backend/tests/api/test_projects_api.py`
-  - [ ] Test: GET /projects returns empty list for new user
-  - [ ] Test: POST /projects creates project and returns it
-  - [ ] Test: GET /projects returns only user's own projects
-  - [ ] Test: POST /projects with empty name returns 422
-  - [ ] Test: Unauthenticated requests return 401
+- [x] **Task 4: Backend Testing** (AC: 1, 2, 3, 4, 5)
+  - [x] Create `backend/tests/api/test_projects_api.py`
+  - [x] Test: GET /projects returns empty list for new user
+  - [x] Test: POST /projects creates project and returns it
+  - [x] Test: GET /projects returns only user's own projects
+  - [x] Test: POST /projects with empty name returns 422
+  - [x] Test: Unauthenticated requests return 401
 
-- [ ] **Task 5: Frontend API Client** (AC: 1, 2)
-  - [ ] Add `ProjectData` interface to `frontend/src/api/client.ts`
-  - [ ] Add `projectsApi` object with `list()` and `create()` methods
-  - [ ] Follow existing authApi pattern
+- [x] **Task 5: Frontend API Client** (AC: 1, 2)
+  - [x] Add `ProjectData` interface to `frontend/src/api/client.ts`
+  - [x] Add `projectsApi` object with `list()` and `create()` methods
+  - [x] Follow existing authApi pattern
 
-- [ ] **Task 6: Projects Page UI** (AC: 1, 2, 5, 6)
-  - [ ] Create `frontend/src/pages/Projects.tsx`
-  - [ ] Display list of projects (name, created date)
-  - [ ] Add "Create Project" form with name input
-  - [ ] Show loading state while fetching
-  - [ ] Show empty state when no projects exist
-  - [ ] Show validation error for empty name
-  - [ ] Style with Tailwind CSS matching existing design
+- [x] **Task 6: Projects Page UI** (AC: 1, 2, 5, 6)
+  - [x] Create `frontend/src/pages/Projects.tsx`
+  - [x] Display list of projects (name, created date)
+  - [x] Add "Create Project" form with name input
+  - [x] Show loading state while fetching
+  - [x] Show empty state when no projects exist
+  - [x] Show validation error for empty name
+  - [x] Style with Tailwind CSS matching existing design
 
-- [ ] **Task 7: Update App Routing** (AC: 1, 4)
-  - [ ] Add `/projects` route to `frontend/src/App.tsx`
-  - [ ] Wrap with ProtectedRoute
-  - [ ] Update Dashboard to link to Projects page (or make Projects the new dashboard)
+- [x] **Task 7: Update App Routing** (AC: 1, 4)
+  - [x] Add `/projects` route to `frontend/src/App.tsx`
+  - [x] Wrap with ProtectedRoute
+  - [x] Update Dashboard to link to Projects page (or make Projects the new dashboard)
 
-- [ ] **Task 8: Frontend Testing** (AC: 1, 2, 5, 6)
-  - [ ] Create `frontend/src/pages/Projects.test.tsx`
-  - [ ] Test: Projects page renders project list
-  - [ ] Test: Create form submits and adds project to list
-  - [ ] Test: Empty name shows validation error
-  - [ ] Test: Empty state displays when no projects
+- [x] **Task 8: Frontend Testing** (AC: 1, 2, 5, 6)
+  - [x] Create `frontend/src/pages/Projects.test.tsx`
+  - [x] Test: Projects page renders project list
+  - [x] Test: Create form submits and adds project to list
+  - [x] Test: Empty name shows validation error
+  - [x] Test: Empty state displays when no projects
 
 ## Dev Notes
 
@@ -269,26 +269,36 @@ export const projectsApi = {
 
 ### Agent Model Used
 
-(To be filled by dev agent)
+GPT-5 (Codex CLI)
 
 ### Completion Notes List
 
-(To be filled by dev agent)
+- Added Project model, schemas, and projects router with authenticated list/create endpoints.
+- Implemented Projects page UI, API client, and routing from Dashboard.
+- Added backend API coverage plus frontend Projects page tests and updated Dashboard tests.
+- Tests: `python -m unittest backend.tests.unit.test_project_model`, `python -m unittest backend.tests.unit.test_project_schema`, `python -m unittest backend.tests.unit.test_projects_router`, `python -m unittest backend.tests.api.test_projects_api`, `npm test` (frontend), `scripts/windows/run-backend-tests.bat`, `scripts/windows/run-frontend-tests.bat`.
 
 ### File List
 
-**To Create:**
+**Created:**
 - backend/app/models/project.py
-- backend/app/schemas/project.py
 - backend/app/routers/projects.py
+- backend/app/schemas/project.py
 - backend/tests/api/test_projects_api.py
-- frontend/src/pages/Projects.tsx
+- backend/tests/unit/test_project_model.py
+- backend/tests/unit/test_project_schema.py
+- backend/tests/unit/test_projects_router.py
 - frontend/src/pages/Projects.test.tsx
+- frontend/src/pages/Projects.tsx
 
-**To Modify:**
-- backend/app/models/__init__.py (export Project)
-- backend/app/schemas/__init__.py (export project schemas)
-- backend/app/main.py (register projects router)
-- backend/app/models/user.py (add projects relationship - optional)
-- frontend/src/api/client.ts (add projectsApi)
-- frontend/src/App.tsx (add /projects route)
+**Modified:**
+- backend/app/main.py
+- backend/app/models/__init__.py
+- backend/app/models/user.py
+- backend/app/routers/__init__.py
+- backend/app/schemas/__init__.py
+- frontend/src/App.tsx
+- frontend/src/api/client.ts
+- frontend/src/components/Header.test.tsx
+- frontend/src/pages/Dashboard.test.tsx
+- frontend/src/pages/Dashboard.tsx

--- a/_bmad-output/implementation-artifacts/2-1-project-list-create.md
+++ b/_bmad-output/implementation-artifacts/2-1-project-list-create.md
@@ -278,7 +278,8 @@ GPT-5 (Codex CLI)
 - Added backend API coverage plus frontend Projects page tests and updated Dashboard tests.
 - Hardened project name validation against whitespace-only values and added coverage.
 - Redirects unauthorized project list/create responses via logout handler.
-- Projects endpoints use async handlers with threadpool for DB I/O.
+- Projects endpoints avoid cross-thread DB sessions for safety.
+- Standardized auth error handling on status codes in auth routes and Projects UI.
 - Tests: `python -m unittest backend.tests.unit.test_project_model`, `python -m unittest backend.tests.unit.test_project_schema`, `python -m unittest backend.tests.unit.test_projects_router`, `python -m unittest backend.tests.api.test_projects_api`, `npm test` (frontend), `scripts/windows/run-backend-tests.bat`, `scripts/windows/run-frontend-tests.bat`.
   - Additional: `python -m unittest backend.tests.unit.test_project_schema` (post-review fix).
 
@@ -306,6 +307,10 @@ GPT-5 (Codex CLI)
 - backend/tests/unit/test_project_schema.py
 - frontend/src/App.tsx
 - frontend/src/api/client.ts
+- frontend/src/components/ProtectedRoute.tsx
+- frontend/src/components/PublicRoute.tsx
+- frontend/src/components/ProtectedRoute.test.tsx
+- frontend/src/components/PublicRoute.test.tsx
 - frontend/src/components/Header.test.tsx
 - frontend/src/pages/Dashboard.test.tsx
 - frontend/src/pages/Dashboard.tsx

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -43,7 +43,7 @@ development_status:
 
   # Epic 2: Project Management
   epic-2: in-progress
-  2-1-project-list-create: ready-for-dev
+  2-1-project-list-create: review
   2-2-view-project-details: backlog
   2-3-edit-project: backlog
   2-4-delete-project: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -39,11 +39,11 @@ development_status:
   1-2-user-login: done
   1-3-user-logout: done
   1-4-protected-routes: done
-  epic-1-retrospective: optional
+  epic-1-retrospective: done
 
   # Epic 2: Project Management
-  epic-2: backlog
-  2-1-project-list-create: backlog
+  epic-2: in-progress
+  2-1-project-list-create: ready-for-dev
   2-2-view-project-details: backlog
   2-3-edit-project: backlog
   2-4-delete-project: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -43,7 +43,7 @@ development_status:
 
   # Epic 2: Project Management
   epic-2: in-progress
-  2-1-project-list-create: review
+  2-1-project-list-create: done
   2-2-view-project-details: backlog
   2-3-edit-project: backlog
   2-4-delete-project: backlog

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,7 +5,8 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.exc import OperationalError
 
-from .routers import auth_router
+from .routers import auth_router, projects_router
+from .models import Project
 from . import database as db
 from .config import FRONTEND_URLS
 
@@ -28,6 +29,7 @@ app.add_middleware(
 
 # Include routers
 app.include_router(auth_router, prefix="/api/auth", tags=["auth"])
+app.include_router(projects_router, prefix="/api", tags=["projects"])
 
 def init_db(max_attempts: int = 10, delay_seconds: float = 1.0) -> None:
     """Initialize database tables with a simple retry for container startup."""

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,4 @@
+from .project import Project
 from .user import User
 
-__all__ = ["User"]
+__all__ = ["User", "Project"]

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -1,0 +1,22 @@
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+from ..database import Base
+
+
+class Project(Base):
+    __tablename__ = "projects"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    owner = relationship("User", back_populates="projects")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 from sqlalchemy import Boolean, Column, DateTime, Integer, String
+from sqlalchemy.orm import relationship
 
 from ..database import Base
 
@@ -17,3 +18,5 @@ class User(Base):
     locked_until = Column(DateTime, nullable=True)
     refresh_token_hash = Column(String, nullable=True)
     refresh_token_expires_at = Column(DateTime, nullable=True)
+
+    projects = relationship("Project", back_populates="owner", cascade="all, delete-orphan")

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,3 +1,4 @@
 from .auth import router as auth_router
+from .projects import router as projects_router
 
-__all__ = ["auth_router"]
+__all__ = ["auth_router", "projects_router"]

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..models.project import Project
+from ..models.user import User
+from ..schemas.project import (
+    ProjectCreate,
+    ProjectDataResponse,
+    ProjectListResponse,
+    ProjectResponse,
+)
+from ..utils.auth import get_current_user
+
+router = APIRouter(prefix="/projects", tags=["projects"])
+
+
+@router.get("", response_model=ProjectListResponse)
+def list_projects(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    projects = db.query(Project).filter(Project.user_id == current_user.id).all()
+    return ProjectListResponse(data=projects)
+
+
+@router.post("", response_model=ProjectDataResponse, status_code=status.HTTP_201_CREATED)
+def create_project(
+    project_data: ProjectCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    project = Project(name=project_data.name, user_id=current_user.id)
+    db.add(project)
+    db.commit()
+    db.refresh(project)
+    return ProjectDataResponse(data=ProjectResponse.model_validate(project))

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, status
+from starlette.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
 from ..database import get_db
@@ -16,22 +17,33 @@ router = APIRouter(prefix="/projects", tags=["projects"])
 
 
 @router.get("", response_model=ProjectListResponse)
-def list_projects(
+async def list_projects(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    projects = db.query(Project).filter(Project.user_id == current_user.id).all()
+    def _load_projects() -> list[Project]:
+        return (
+            db.query(Project)
+            .filter(Project.user_id == current_user.id)
+            .all()
+        )
+
+    projects = await run_in_threadpool(_load_projects)
     return ProjectListResponse(data=projects)
 
 
 @router.post("", response_model=ProjectDataResponse, status_code=status.HTTP_201_CREATED)
-def create_project(
+async def create_project(
     project_data: ProjectCreate,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    project = Project(name=project_data.name, user_id=current_user.id)
-    db.add(project)
-    db.commit()
-    db.refresh(project)
-    return ProjectDataResponse(data=ProjectResponse.model_validate(project))
+    def _create_project() -> ProjectResponse:
+        project = Project(name=project_data.name, user_id=current_user.id)
+        db.add(project)
+        db.commit()
+        db.refresh(project)
+        return ProjectResponse.model_validate(project)
+
+    project = await run_in_threadpool(_create_project)
+    return ProjectDataResponse(data=project)

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -1,5 +1,4 @@
 from fastapi import APIRouter, Depends, status
-from starlette.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
 from ..database import get_db
@@ -17,33 +16,22 @@ router = APIRouter(prefix="/projects", tags=["projects"])
 
 
 @router.get("", response_model=ProjectListResponse)
-async def list_projects(
+def list_projects(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    def _load_projects() -> list[Project]:
-        return (
-            db.query(Project)
-            .filter(Project.user_id == current_user.id)
-            .all()
-        )
-
-    projects = await run_in_threadpool(_load_projects)
+    projects = db.query(Project).filter(Project.user_id == current_user.id).all()
     return ProjectListResponse(data=projects)
 
 
 @router.post("", response_model=ProjectDataResponse, status_code=status.HTTP_201_CREATED)
-async def create_project(
+def create_project(
     project_data: ProjectCreate,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    def _create_project() -> ProjectResponse:
-        project = Project(name=project_data.name, user_id=current_user.id)
-        db.add(project)
-        db.commit()
-        db.refresh(project)
-        return ProjectResponse.model_validate(project)
-
-    project = await run_in_threadpool(_create_project)
-    return ProjectDataResponse(data=project)
+    project = Project(name=project_data.name, user_id=current_user.id)
+    db.add(project)
+    db.commit()
+    db.refresh(project)
+    return ProjectDataResponse(data=ProjectResponse.model_validate(project))

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,3 +1,16 @@
+from .project import (
+    ProjectCreate,
+    ProjectDataResponse,
+    ProjectListResponse,
+    ProjectResponse,
+)
 from .user import UserCreate, UserResponse
 
-__all__ = ["UserCreate", "UserResponse"]
+__all__ = [
+    "ProjectCreate",
+    "ProjectDataResponse",
+    "ProjectListResponse",
+    "ProjectResponse",
+    "UserCreate",
+    "UserResponse",
+]

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -1,10 +1,18 @@
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class ProjectCreate(BaseModel):
     name: str = Field(min_length=1)
+
+    @field_validator("name")
+    @classmethod
+    def name_not_blank(cls, value: str) -> str:
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("Project name cannot be blank")
+        return trimmed
 
 
 class ProjectResponse(BaseModel):

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class ProjectCreate(BaseModel):
+    name: str = Field(min_length=1)
+
+
+class ProjectResponse(BaseModel):
+    id: int
+    name: str
+    user_id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class ProjectListResponse(BaseModel):
+    data: list[ProjectResponse]
+
+
+class ProjectDataResponse(BaseModel):
+    data: ProjectResponse

--- a/backend/tests/api/test_projects_api.py
+++ b/backend/tests/api/test_projects_api.py
@@ -1,0 +1,140 @@
+import os
+import unittest
+
+os.environ.setdefault("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend.app import database as db
+from backend.app.database import get_db
+
+
+class ProjectsApiTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        db.engine = cls.engine
+        db.SessionLocal = sessionmaker(
+            autocommit=False, autoflush=False, bind=cls.engine
+        )
+        db.Base.metadata.create_all(bind=cls.engine)
+
+        def override_get_db():
+            session = db.SessionLocal()
+            try:
+                yield session
+            finally:
+                session.close()
+
+        from backend.app import main
+        from backend.app.models.user import User
+        from backend.app.models.project import Project
+        cls.User = User
+        cls.Project = Project
+        main.app.dependency_overrides[get_db] = override_get_db
+        cls.client = TestClient(main.app)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.engine.dispose()
+
+    def setUp(self):
+        db.Base.metadata.drop_all(bind=self.engine)
+        db.Base.metadata.create_all(bind=self.engine)
+
+    def _create_user(self, email: str, password: str):
+        from backend.app.utils.auth import hash_password
+
+        session = db.SessionLocal()
+        try:
+            user = self.User(
+                email=email,
+                hashed_password=hash_password(password),
+                is_verified=True,
+                is_active=True,
+            )
+            session.add(user)
+            session.commit()
+            session.refresh(user)
+            return user
+        finally:
+            session.close()
+
+    def _auth_header_for(self, email: str):
+        from backend.app.utils.auth import create_access_token
+
+        token = create_access_token({"sub": email})
+        return {"Authorization": f"Bearer {token}"}
+
+    def test_list_projects_empty_for_new_user(self):
+        user = self._create_user("user@example.com", "secret123")
+        response = self.client.get(
+            "/api/projects",
+            headers=self._auth_header_for(user.email),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["data"], [])
+
+    def test_create_project_returns_project(self):
+        user = self._create_user("user@example.com", "secret123")
+        response = self.client.post(
+            "/api/projects",
+            json={"name": "My Project"},
+            headers=self._auth_header_for(user.email),
+        )
+
+        self.assertEqual(response.status_code, 201)
+        body = response.json()
+        self.assertEqual(body["data"]["name"], "My Project")
+        self.assertEqual(body["data"]["user_id"], user.id)
+
+    def test_list_projects_only_returns_current_user(self):
+        user_a = self._create_user("a@example.com", "secret123")
+        user_b = self._create_user("b@example.com", "secret123")
+
+        session = db.SessionLocal()
+        try:
+            session.add(self.Project(name="A project", user_id=user_a.id))
+            session.add(self.Project(name="B project", user_id=user_b.id))
+            session.commit()
+        finally:
+            session.close()
+
+        response = self.client.get(
+            "/api/projects",
+            headers=self._auth_header_for(user_a.email),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()["data"]
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["name"], "A project")
+
+    def test_create_project_empty_name_returns_422(self):
+        user = self._create_user("user@example.com", "secret123")
+        response = self.client.post(
+            "/api/projects",
+            json={"name": ""},
+            headers=self._auth_header_for(user.email),
+        )
+
+        self.assertEqual(response.status_code, 422)
+
+    def test_unauthenticated_requests_return_401(self):
+        response = self.client.get("/api/projects")
+        self.assertEqual(response.status_code, 401)
+
+        response = self.client.post("/api/projects", json={"name": "Test"})
+        self.assertEqual(response.status_code, 401)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/unit/test_project_model.py
+++ b/backend/tests/unit/test_project_model.py
@@ -1,0 +1,48 @@
+import unittest
+
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend.app.database import Base
+from backend.app.models.project import Project
+
+
+class ProjectModelTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        cls.SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=cls.engine)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.engine.dispose()
+
+    def setUp(self):
+        Base.metadata.drop_all(bind=self.engine)
+        Base.metadata.create_all(bind=self.engine)
+        self.db = self.SessionLocal()
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_project_table_exists(self):
+        inspector = inspect(self.engine)
+        self.assertIn("projects", inspector.get_table_names())
+
+    def test_project_columns_exist(self):
+        inspector = inspect(self.engine)
+        columns = {col["name"] for col in inspector.get_columns("projects")}
+        self.assertIn("id", columns)
+        self.assertIn("name", columns)
+        self.assertIn("user_id", columns)
+        self.assertIn("created_at", columns)
+        self.assertIn("updated_at", columns)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/unit/test_project_schema.py
+++ b/backend/tests/unit/test_project_schema.py
@@ -10,6 +10,10 @@ class ProjectSchemaTests(unittest.TestCase):
         with self.assertRaises(ValidationError):
             ProjectCreate(name="")
 
+    def test_project_create_rejects_whitespace_only_name(self):
+        with self.assertRaises(ValidationError):
+            ProjectCreate(name="   ")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/unit/test_project_schema.py
+++ b/backend/tests/unit/test_project_schema.py
@@ -1,0 +1,15 @@
+import unittest
+
+from pydantic import ValidationError
+
+from backend.app.schemas.project import ProjectCreate
+
+
+class ProjectSchemaTests(unittest.TestCase):
+    def test_project_create_requires_name(self):
+        with self.assertRaises(ValidationError):
+            ProjectCreate(name="")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/unit/test_projects_router.py
+++ b/backend/tests/unit/test_projects_router.py
@@ -1,0 +1,13 @@
+import unittest
+
+
+class ProjectsRouterTests(unittest.TestCase):
+    def test_projects_router_has_routes(self):
+        from backend.app.routers.projects import router
+
+        paths = {route.path for route in router.routes}
+        self.assertIn("/projects", paths)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import Login from './pages/Login';
 import Register from './pages/Register';
 import Dashboard from './pages/Dashboard';
+import Projects from './pages/Projects';
 import ProtectedRoute from './components/ProtectedRoute';
 import PublicRoute from './components/PublicRoute';
 
@@ -31,6 +32,14 @@ function App() {
             element={
               <ProtectedRoute>
                 <Dashboard />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/projects"
+            element={
+              <ProtectedRoute>
+                <Projects />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -81,6 +81,18 @@ export interface RefreshResponse {
   token_type: string;
 }
 
+export interface ProjectData {
+  id: number;
+  name: string;
+  user_id: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateProjectData {
+  name: string;
+}
+
 export const authApi = {
   register: (data: RegisterData) =>
     api.post<ApiResponse<UserData>>('/auth/register', data),
@@ -91,4 +103,10 @@ export const authApi = {
   me: () => api.get<ApiResponse<UserData>>('/auth/me'),
   logout: (refresh_token: string) =>
     api.post<null>('/auth/logout', { refresh_token }),
+};
+
+export const projectsApi = {
+  list: () => api.get<ApiResponse<ProjectData[]>>('/projects'),
+  create: (data: CreateProjectData) =>
+    api.post<ApiResponse<ProjectData>>('/projects', data),
 };

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -9,6 +9,18 @@ interface ApiError {
   detail: string;
 }
 
+export class ApiRequestError extends Error {
+  status: number;
+  detail?: string;
+
+  constructor(status: number, detail?: string) {
+    super(detail || 'An error occurred');
+    this.name = 'ApiRequestError';
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
 async function request<T>(
   endpoint: string,
   options: RequestInit = {}
@@ -27,8 +39,16 @@ async function request<T>(
   });
 
   if (!response.ok) {
-    const error: ApiError = await response.json();
-    throw new Error(error.detail || 'An error occurred');
+    let detail: string | undefined;
+    try {
+      const error: ApiError = await response.json();
+      if (error && typeof error.detail === 'string') {
+        detail = error.detail;
+      }
+    } catch {
+      // Ignore JSON parsing errors for non-JSON responses.
+    }
+    throw new ApiRequestError(response.status, detail);
   }
 
   return response.json();

--- a/frontend/src/components/Header.test.tsx
+++ b/frontend/src/components/Header.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import Dashboard from '../pages/Dashboard';
 
 const mockNavigate = vi.fn();
@@ -23,7 +24,11 @@ vi.mock('../api/client', () => ({
 describe('Header', () => {
   it('shows the logout button on the dashboard', () => {
     localStorage.setItem('token', 'access-token');
-    render(<Dashboard />);
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>
+    );
     expect(screen.getByRole('button', { name: /logout/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/ProtectedRoute.test.tsx
+++ b/frontend/src/components/ProtectedRoute.test.tsx
@@ -3,13 +3,19 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import ProtectedRoute from './ProtectedRoute';
 
-vi.mock('../api/client', () => ({
-  authApi: {
-    me: vi.fn(),
-  },
-}));
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>(
+    '../api/client'
+  );
+  return {
+    ...actual,
+    authApi: {
+      me: vi.fn(),
+    },
+  };
+});
 
-import { authApi } from '../api/client';
+import { ApiRequestError, authApi } from '../api/client';
 
 describe('ProtectedRoute', () => {
   beforeEach(() => {
@@ -116,7 +122,7 @@ describe('ProtectedRoute', () => {
 
   it('redirects to login when server rejects token', async () => {
     localStorage.setItem('token', makeToken(60));
-    vi.mocked(authApi.me).mockRejectedValue(new Error('401 Unauthorized'));
+    vi.mocked(authApi.me).mockRejectedValue(new ApiRequestError(401, 'Not authenticated'));
 
     render(
       <MemoryRouter initialEntries={['/dashboard']}>
@@ -139,7 +145,7 @@ describe('ProtectedRoute', () => {
 
   it('allows access when server errors are transient', async () => {
     localStorage.setItem('token', makeToken(60));
-    vi.mocked(authApi.me).mockRejectedValue(new Error('500 Server error'));
+    vi.mocked(authApi.me).mockRejectedValue(new ApiRequestError(500, 'Server error'));
 
     render(
       <MemoryRouter initialEntries={['/dashboard']}>

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
-import { authApi } from '../api/client';
+import { ApiRequestError, authApi } from '../api/client';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
@@ -44,8 +44,9 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
         }
       })
       .catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : '';
-        const isAuthError = message.toLowerCase().includes('401') || message.toLowerCase().includes('403');
+        const isAuthError =
+          err instanceof ApiRequestError &&
+          (err.status === 401 || err.status === 403);
         if (isAuthError) {
           localStorage.removeItem('token');
         }

--- a/frontend/src/components/PublicRoute.test.tsx
+++ b/frontend/src/components/PublicRoute.test.tsx
@@ -4,13 +4,19 @@ import { render, screen } from '@testing-library/react';
 import PublicRoute from './PublicRoute';
 import Login from '../pages/Login';
 
-vi.mock('../api/client', () => ({
-  authApi: {
-    me: vi.fn(),
-  },
-}));
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>(
+    '../api/client'
+  );
+  return {
+    ...actual,
+    authApi: {
+      me: vi.fn(),
+    },
+  };
+});
 
-import { authApi } from '../api/client';
+import { ApiRequestError, authApi } from '../api/client';
 
 describe('PublicRoute', () => {
   beforeEach(() => {
@@ -87,7 +93,7 @@ describe('PublicRoute', () => {
 
   it('keeps unauthenticated users on login when token is rejected', async () => {
     localStorage.setItem('token', makeToken(60));
-    vi.mocked(authApi.me).mockRejectedValue(new Error('401 Unauthorized'));
+    vi.mocked(authApi.me).mockRejectedValue(new ApiRequestError(401, 'Not authenticated'));
 
     render(
       <MemoryRouter initialEntries={['/login']}>
@@ -107,7 +113,7 @@ describe('PublicRoute', () => {
 
   it('redirects authenticated users when server error is transient', async () => {
     localStorage.setItem('token', makeToken(60));
-    vi.mocked(authApi.me).mockRejectedValue(new Error('500 Server error'));
+    vi.mocked(authApi.me).mockRejectedValue(new ApiRequestError(500, 'Server error'));
 
     render(
       <MemoryRouter initialEntries={['/login']}>

--- a/frontend/src/components/PublicRoute.tsx
+++ b/frontend/src/components/PublicRoute.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Navigate } from 'react-router-dom';
-import { authApi } from '../api/client';
+import { ApiRequestError, authApi } from '../api/client';
 
 interface PublicRouteProps {
   children: React.ReactNode;
@@ -43,8 +43,9 @@ export default function PublicRoute({ children }: PublicRouteProps) {
         }
       })
       .catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : '';
-        const isAuthError = message.toLowerCase().includes('401') || message.toLowerCase().includes('403');
+        const isAuthError =
+          err instanceof ApiRequestError &&
+          (err.status === 401 || err.status === 403);
         if (isAuthError) {
           localStorage.removeItem('token');
         }

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import Dashboard from './Dashboard';
 
 const mockNavigate = vi.fn();
@@ -27,7 +28,11 @@ describe('Dashboard', () => {
   });
 
   it('redirects to login when token is missing', async () => {
-    render(<Dashboard />);
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>
+    );
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/login');
@@ -36,7 +41,11 @@ describe('Dashboard', () => {
 
   it('does not redirect when token exists', async () => {
     localStorage.setItem('token', 'access-token');
-    render(<Dashboard />);
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>
+    );
 
     await waitFor(() => {
       expect(mockNavigate).not.toHaveBeenCalled();

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import Header from '../components/Header';
 import { useLogout } from '../hooks/useLogout';
 
@@ -21,6 +21,12 @@ export default function Dashboard() {
         <div className="rounded-lg bg-white p-8 shadow-md">
           <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
           <p className="mt-2 text-gray-600">You are logged in.</p>
+          <Link
+            to="/projects"
+            className="mt-4 inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            View projects
+          </Link>
         </div>
       </main>
     </div>

--- a/frontend/src/pages/Projects.test.tsx
+++ b/frontend/src/pages/Projects.test.tsx
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import Projects from './Projects';
+
+vi.mock('../api/client', () => ({
+  projectsApi: {
+    list: vi.fn(),
+    create: vi.fn(),
+  },
+}));
+
+vi.mock('../hooks/useLogout', () => ({
+  useLogout: () => ({ logout: vi.fn() }),
+}));
+
+import { projectsApi } from '../api/client';
+
+describe('Projects page', () => {
+  beforeEach(() => {
+    vi.mocked(projectsApi.list).mockReset();
+    vi.mocked(projectsApi.create).mockReset();
+  });
+
+  it('renders project list', async () => {
+    vi.mocked(projectsApi.list).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          name: 'Launch Plan',
+          user_id: 1,
+          created_at: '2026-01-21T00:00:00Z',
+          updated_at: '2026-01-21T00:00:00Z',
+        },
+      ],
+    });
+
+    render(<Projects />);
+
+    expect(await screen.findByText('Launch Plan')).toBeInTheDocument();
+  });
+
+  it('creates a project and adds it to the list', async () => {
+    vi.mocked(projectsApi.list).mockResolvedValue({ data: [] });
+    vi.mocked(projectsApi.create).mockResolvedValue({
+      data: {
+        id: 2,
+        name: 'New Project',
+        user_id: 1,
+        created_at: '2026-01-21T00:00:00Z',
+        updated_at: '2026-01-21T00:00:00Z',
+      },
+    });
+
+    render(<Projects />);
+
+    await screen.findByText(/you have not created any projects yet/i);
+
+    fireEvent.change(screen.getByLabelText(/project name/i), {
+      target: { value: 'New Project' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create project/i }));
+
+    await waitFor(() => {
+      expect(projectsApi.create).toHaveBeenCalledWith({ name: 'New Project' });
+    });
+    expect(await screen.findByText('New Project')).toBeInTheDocument();
+  });
+
+  it('shows validation error for empty name', async () => {
+    vi.mocked(projectsApi.list).mockResolvedValue({ data: [] });
+
+    render(<Projects />);
+
+    await screen.findByText(/you have not created any projects yet/i);
+
+    fireEvent.click(screen.getByRole('button', { name: /create project/i }));
+
+    expect(await screen.findByText(/project name is required/i)).toBeInTheDocument();
+    expect(projectsApi.create).not.toHaveBeenCalled();
+  });
+
+  it('shows empty state when there are no projects', async () => {
+    vi.mocked(projectsApi.list).mockResolvedValue({ data: [] });
+
+    render(<Projects />);
+
+    expect(
+      await screen.findByText(/you have not created any projects yet/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Projects.test.tsx
+++ b/frontend/src/pages/Projects.test.tsx
@@ -9,8 +9,10 @@ vi.mock('../api/client', () => ({
   },
 }));
 
+const mockLogout = vi.fn();
+
 vi.mock('../hooks/useLogout', () => ({
-  useLogout: () => ({ logout: vi.fn() }),
+  useLogout: () => ({ logout: mockLogout }),
 }));
 
 import { projectsApi } from '../api/client';
@@ -19,6 +21,7 @@ describe('Projects page', () => {
   beforeEach(() => {
     vi.mocked(projectsApi.list).mockReset();
     vi.mocked(projectsApi.create).mockReset();
+    mockLogout.mockReset();
   });
 
   it('renders project list', async () => {
@@ -87,5 +90,33 @@ describe('Projects page', () => {
     expect(
       await screen.findByText(/you have not created any projects yet/i)
     ).toBeInTheDocument();
+  });
+
+  it('logs out on unauthorized list response', async () => {
+    vi.mocked(projectsApi.list).mockRejectedValue(new Error('401 Unauthorized'));
+
+    render(<Projects />);
+
+    await waitFor(() => {
+      expect(mockLogout).toHaveBeenCalled();
+    });
+  });
+
+  it('logs out on unauthorized create response', async () => {
+    vi.mocked(projectsApi.list).mockResolvedValue({ data: [] });
+    vi.mocked(projectsApi.create).mockRejectedValue(new Error('403 Forbidden'));
+
+    render(<Projects />);
+
+    await screen.findByText(/you have not created any projects yet/i);
+
+    fireEvent.change(screen.getByLabelText(/project name/i), {
+      target: { value: 'New Project' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create project/i }));
+
+    await waitFor(() => {
+      expect(mockLogout).toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/src/pages/Projects.test.tsx
+++ b/frontend/src/pages/Projects.test.tsx
@@ -2,12 +2,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import Projects from './Projects';
 
-vi.mock('../api/client', () => ({
-  projectsApi: {
-    list: vi.fn(),
-    create: vi.fn(),
-  },
-}));
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>(
+    '../api/client'
+  );
+  return {
+    ...actual,
+    projectsApi: {
+      list: vi.fn(),
+      create: vi.fn(),
+    },
+  };
+});
 
 const mockLogout = vi.fn();
 
@@ -15,7 +21,7 @@ vi.mock('../hooks/useLogout', () => ({
   useLogout: () => ({ logout: mockLogout }),
 }));
 
-import { projectsApi } from '../api/client';
+import { ApiRequestError, projectsApi } from '../api/client';
 
 describe('Projects page', () => {
   beforeEach(() => {
@@ -93,7 +99,7 @@ describe('Projects page', () => {
   });
 
   it('logs out on unauthorized list response', async () => {
-    vi.mocked(projectsApi.list).mockRejectedValue(new Error('401 Unauthorized'));
+    vi.mocked(projectsApi.list).mockRejectedValue(new ApiRequestError(401, 'Not authenticated'));
 
     render(<Projects />);
 
@@ -104,7 +110,7 @@ describe('Projects page', () => {
 
   it('logs out on unauthorized create response', async () => {
     vi.mocked(projectsApi.list).mockResolvedValue({ data: [] });
-    vi.mocked(projectsApi.create).mockRejectedValue(new Error('403 Forbidden'));
+    vi.mocked(projectsApi.create).mockRejectedValue(new ApiRequestError(403, 'Forbidden'));
 
     render(<Projects />);
 

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -1,0 +1,139 @@
+import { FormEvent, useEffect, useState } from 'react';
+import Header from '../components/Header';
+import { projectsApi } from '../api/client';
+import type { ProjectData } from '../api/client';
+import { useLogout } from '../hooks/useLogout';
+
+export default function Projects() {
+  const { logout } = useLogout();
+  const userEmail = localStorage.getItem('user_email');
+  const [projects, setProjects] = useState<ProjectData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [name, setName] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    projectsApi
+      .list()
+      .then((response) => {
+        if (!active) return;
+        setProjects(response.data);
+        setError(null);
+      })
+      .catch((err) => {
+        if (!active) return;
+        setError(err instanceof Error ? err.message : 'Failed to load projects');
+      })
+      .finally(() => {
+        if (!active) return;
+        setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedName = name.trim();
+
+    if (!trimmedName) {
+      setFormError('Project name is required.');
+      return;
+    }
+
+    setFormError(null);
+    setSubmitting(true);
+    try {
+      const response = await projectsApi.create({ name: trimmedName });
+      setProjects((prev) => [response.data, ...prev]);
+      setName('');
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Unable to create project');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-100">
+      <Header onLogout={logout} userEmail={userEmail} />
+      <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-8 px-6 pb-12 pt-24">
+        <section className="rounded-lg bg-white p-6 shadow-md">
+          <h1 className="text-2xl font-bold text-gray-900">Projects</h1>
+          <p className="mt-2 text-gray-600">
+            Create and organize your projects.
+          </p>
+          <form onSubmit={handleSubmit} className="mt-6 space-y-3">
+            <div>
+              <label htmlFor="project-name" className="text-sm font-medium text-gray-700">
+                Project name
+              </label>
+              <input
+                id="project-name"
+                type="text"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                className="mt-2 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                placeholder="e.g. Marketing site refresh"
+              />
+            </div>
+            {formError ? (
+              <p className="text-sm text-red-600">{formError}</p>
+            ) : null}
+            <button
+              type="submit"
+              disabled={submitting}
+              className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {submitting ? 'Creating...' : 'Create Project'}
+            </button>
+          </form>
+        </section>
+
+        <section className="rounded-lg bg-white p-6 shadow-md">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-gray-900">Your projects</h2>
+          </div>
+          <div className="mt-4">
+            {loading ? (
+              <p className="text-sm text-gray-600">Loading projects...</p>
+            ) : error ? (
+              <p className="text-sm text-red-600">{error}</p>
+            ) : projects.length === 0 ? (
+              <p className="text-sm text-gray-600">
+                You have not created any projects yet.
+              </p>
+            ) : (
+              <ul className="space-y-3">
+                {projects.map((project) => (
+                  <li
+                    key={project.id}
+                    className="rounded-md border border-gray-200 px-4 py-3"
+                  >
+                    <p className="text-sm font-semibold text-gray-900">
+                      {project.name}
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      Created{' '}
+                      {new Date(project.created_at).toLocaleDateString(undefined, {
+                        year: 'numeric',
+                        month: 'short',
+                        day: 'numeric',
+                      })}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useEffect, useState } from 'react';
 import Header from '../components/Header';
-import { projectsApi } from '../api/client';
+import { ApiRequestError, projectsApi } from '../api/client';
 import type { ProjectData } from '../api/client';
 import { useLogout } from '../hooks/useLogout';
 
@@ -8,8 +8,7 @@ export default function Projects() {
   const { logout } = useLogout();
   const userEmail = localStorage.getItem('user_email');
   const handleAuthError = (err: unknown) => {
-    const message = err instanceof Error ? err.message : '';
-    if (message.toLowerCase().includes('401') || message.toLowerCase().includes('403')) {
+    if (err instanceof ApiRequestError && (err.status === 401 || err.status === 403)) {
       logout();
       return true;
     }

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -7,6 +7,14 @@ import { useLogout } from '../hooks/useLogout';
 export default function Projects() {
   const { logout } = useLogout();
   const userEmail = localStorage.getItem('user_email');
+  const handleAuthError = (err: unknown) => {
+    const message = err instanceof Error ? err.message : '';
+    if (message.toLowerCase().includes('401') || message.toLowerCase().includes('403')) {
+      logout();
+      return true;
+    }
+    return false;
+  };
   const [projects, setProjects] = useState<ProjectData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -26,6 +34,9 @@ export default function Projects() {
       })
       .catch((err) => {
         if (!active) return;
+        if (handleAuthError(err)) {
+          return;
+        }
         setError(err instanceof Error ? err.message : 'Failed to load projects');
       })
       .finally(() => {
@@ -54,6 +65,9 @@ export default function Projects() {
       setProjects((prev) => [response.data, ...prev]);
       setName('');
     } catch (err) {
+      if (handleAuthError(err)) {
+        return;
+      }
       setFormError(err instanceof Error ? err.message : 'Unable to create project');
     } finally {
       setSubmitting(false);


### PR DESCRIPTION
Add projects model, schemas, and authenticated list/create endpoints.
Add Projects page with create form, empty state, and list rendering.
Wire /projects route and dashboard link.
Add backend API/unit tests and frontend page tests.
Apply review fixes: whitespace-only validation, auth error handling, async endpoints.