### PR TITLE
Implement story 2.4 delete project

### DIFF
--- a/_bmad-output/implementation-artifacts/2-4-delete-project.md
+++ b/_bmad-output/implementation-artifacts/2-4-delete-project.md
@@ -1,0 +1,253 @@
+# Story 2.4: Delete Project
+
+Status: done
+
+## Story
+
+As a **user**,
+I want to **delete a project**,
+So that **I can remove projects I no longer need**.
+
+## Acceptance Criteria
+
+1. **Given** I own a project **When** I click "Delete" and confirm **Then** the project is deleted and I am returned to the projects list
+2. **Given** I delete a project **Then** it is removed from my project list
+3. **Given** I click "Delete" and cancel **Then** the project is not deleted and no API call is made
+4. **Given** I try to delete a project I don't own **Then** the API returns 403 Forbidden
+5. **Given** I try to delete a project that doesn't exist **Then** the API returns 404 Not Found
+6. **Given** I am not authenticated **When** I try to delete a project **Then** the API returns 401 Unauthorized
+7. **Given** I am viewing a project **Then** I see a confirmation step before deletion
+8. **Given** I delete a project that was already deleted **Then** the API returns 404 Not Found
+
+## Tasks / Subtasks
+
+- [x] **Task 1: Backend DELETE Endpoint** (AC: 1, 4, 5, 6)
+  - [x] Add `DELETE /api/projects/{project_id}` endpoint to `backend/app/routers/projects.py`
+  - [x] Use `get_current_user` dependency for authentication
+  - [x] Query project by ID, return 404 if not found
+  - [x] Check ownership, return 403 if not owner
+  - [x] Delete project and commit
+  - [x] Return a JSON response body (keep `ApiResponse` parsing intact in frontend)
+
+- [x] **Task 2: Backend Testing** (AC: 1, 4, 5, 6)
+  - [x] Add tests to `backend/tests/api/test_projects_api.py`
+  - [x] Test: DELETE /projects/{id} deletes project for owner
+  - [x] Test: DELETE /projects/{id} returns 404 for non-existent project
+  - [x] Test: DELETE /projects/{id} returns 404 for already deleted project (AC: 8)
+  - [x] Test: DELETE /projects/{id} returns 403 for non-owner
+  - [x] Test: DELETE /projects/{id} returns 401 for unauthenticated request
+
+- [x] **Task 3: Frontend API Client** (AC: 1, 2)
+  - [x] Add `delete(id: number)` method to `projectsApi` in `frontend/src/api/client.ts`
+  - [x] Return `ApiResponse<ProjectData>` (or equivalent JSON) to match API response
+
+- [x] **Task 4: Delete UI in ProjectDetail** (AC: 1, 2, 3, 7)
+  - [x] Add "Delete" button to `frontend/src/pages/ProjectDetail.tsx`
+  - [x] Prompt for confirmation (simple `window.confirm` is acceptable)
+  - [x] If confirmed, call `projectsApi.delete(project.id)`
+  - [x] On success, navigate to `/projects` (list reload removes deleted project)
+  - [x] If cancelled, do nothing
+  - [x] Handle 401 by logging out, 403/404 by showing an error message
+  - [x] Style delete button with destructive styling consistent with existing UI
+
+- [x] **Task 5: Frontend Testing** (AC: 1, 2, 3, 7)
+  - [x] Update `frontend/src/pages/ProjectDetail.test.tsx`
+  - [x] Test: Delete button renders for project
+  - [x] Test: Confirm delete calls API and navigates to /projects
+  - [x] Test: Cancel delete does not call API
+  - [x] Test: 403/404 delete shows error message
+
+## Dev Notes
+
+### Architecture Compliance
+
+**Backend Structure:**
+- Endpoint: `backend/app/routers/projects.py` (add to existing file)
+- Tests: `backend/tests/api/test_projects_api.py` (add to existing file)
+
+**Frontend Structure:**
+- API: `frontend/src/api/client.ts` (add delete method to projectsApi)
+- Page: `frontend/src/pages/ProjectDetail.tsx` (add delete UI)
+- Tests: `frontend/src/pages/ProjectDetail.test.tsx` (add delete tests)
+
+### Technical Requirements
+
+| Requirement | Implementation |
+|-------------|----------------|
+| Authentication | `get_current_user` dependency |
+| Authorization | Check `project.user_id == current_user.id` |
+| 403 Response | `HTTPException(status_code=403, detail="Not authorized to access this project")` |
+| 404 Response | `HTTPException(status_code=404, detail="Project not found")` |
+| Response Format | Must return JSON body (frontend `api.delete` parses JSON) |
+| Confirmation | `window.confirm` or simple inline confirmation step |
+
+### API Endpoint Spec
+
+**DELETE /api/projects/{project_id}** (Protected)
+
+Request Headers:
+```
+Authorization: Bearer <access_token>
+```
+
+Success Response (200):
+```json
+{
+  "data": {
+    "id": 1,
+    "name": "My Project",
+    "user_id": 1,
+    "created_at": "2026-01-21T00:00:00Z",
+    "updated_at": "2026-01-22T12:00:00Z"
+  }
+}
+```
+
+Error Response (401 - not authenticated):
+```json
+{
+  "detail": "Not authenticated"
+}
+```
+
+Error Response (403 - not owner):
+```json
+{
+  "detail": "Not authorized to access this project"
+}
+```
+
+Error Response (404 - not found):
+```json
+{
+  "detail": "Project not found"
+}
+```
+
+### Component Specifications
+
+**Backend DELETE Endpoint:**
+```python
+@router.delete("/{project_id}", response_model=ProjectDataResponse)
+def delete_project(
+    project_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    project = db.query(Project).filter(Project.id == project_id).first()
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+    if project.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorized to access this project")
+    db.delete(project)
+    db.commit()
+    return ProjectDataResponse(data=ProjectResponse.model_validate(project))
+```
+
+**Frontend projectsApi delete:**
+```typescript
+export const projectsApi = {
+  list: () => api.get<ApiResponse<ProjectData[]>>('/projects'),
+  create: (data: CreateProjectData) =>
+    api.post<ApiResponse<ProjectData>>('/projects', data),
+  get: (id: number) => api.get<ApiResponse<ProjectData>>(`/projects/${id}`),
+  update: (id: number, data: UpdateProjectData) =>
+    api.put<ApiResponse<ProjectData>>(`/projects/${id}`, data),
+  delete: (id: number) => api.delete<ApiResponse<ProjectData>>(`/projects/${id}`),
+};
+```
+
+**ProjectDetail delete flow:**
+```tsx
+const handleDelete = async () => {
+  if (!project) return;
+  const confirmed = window.confirm('Delete this project?');
+  if (!confirmed) return;
+
+  try {
+    await projectsApi.delete(project.id);
+    navigate('/projects');
+  } catch (err) {
+    if (err instanceof ApiRequestError) {
+      if (err.status === 401) {
+        logout();
+        return;
+      }
+      if (err.status === 403) {
+        setError('You do not have permission to delete this project.');
+        return;
+      }
+      if (err.status === 404) {
+        setError('Project not found.');
+        return;
+      }
+    }
+    setError(err instanceof Error ? err.message : 'Failed to delete project');
+  }
+};
+```
+
+### References
+
+**Planning Documents:**
+- [PRD: FR9](../planning-artifacts/prd.md)
+- [Architecture: Project Structure](../planning-artifacts/architecture.md)
+- [Epics: Story 2.4](../planning-artifacts/epics.md#Story-2.4-Delete-Project)
+
+**Source: Story 2-3 Implementation Patterns**
+- [backend/app/routers/projects.py](../../backend/app/routers/projects.py) - Add DELETE endpoint here
+- [backend/tests/api/test_projects_api.py](../../backend/tests/api/test_projects_api.py) - Add delete tests here
+- [frontend/src/api/client.ts](../../frontend/src/api/client.ts) - Add delete method here
+- [frontend/src/pages/ProjectDetail.tsx](../../frontend/src/pages/ProjectDetail.tsx) - Add delete UI here
+- [frontend/src/pages/ProjectDetail.test.tsx](../../frontend/src/pages/ProjectDetail.test.tsx) - Add delete tests here
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 (Codex CLI)
+
+### Implementation Plan
+
+- Add backend DELETE endpoint with ownership checks and JSON response.
+- Add backend tests for delete scenarios (owner, 401, 403, 404).
+- Add frontend projectsApi delete method.
+- Add delete flow UI with confirmation and error handling.
+- Add frontend tests for delete flow and navigation.
+
+### Debug Log References
+
+- logs/backend-tests-20260122-230346.log
+- logs/frontend-tests-20260122-230401.log
+
+### Completion Notes List
+
+- Added DELETE /api/projects/{id} with 401/403/404 handling and JSON response.
+- Added backend delete tests (owner success, 401, 403, 404) with response body assertions and delete-twice 404 behavior.
+- Added projectsApi.delete and delete button flow with confirm + navigation, plus delete-in-progress UI state.
+- Added delete UI error handling and destructive button styling, with error reset on success and edit disabled during delete.
+- Added frontend delete tests for confirm/cancel and error states, including 401 logout, deleting state, and no-navigation on failure.
+- Prevented delete re-entry during confirmation by setting deleting state pre-confirm.
+- Documented AC8 in tasks and aligned test naming.
+- Tests: scripts/windows/run-backend-tests.ps1, scripts/windows/run-frontend-tests.ps1 (pass).
+
+### File List
+
+**Modified:**
+- backend/app/routers/projects.py
+- backend/tests/api/test_projects_api.py
+- frontend/src/api/client.ts
+- frontend/src/pages/ProjectDetail.tsx
+- frontend/src/pages/ProjectDetail.test.tsx
+- _bmad-output/implementation-artifacts/2-4-delete-project.md
+- _bmad-output/implementation-artifacts/sprint-status.yaml
+
+### Change Log
+
+- 2026-01-23: Implemented Story 2.4 delete project endpoint, UI, tests, and updated sprint status.
+- 2026-01-23: Code review fixes: safe delete response serialization, delete loading state, 401 delete test.
+- 2026-01-23: Final review fixes: async delete handler, delete response assertions, delete loading test.
+- 2026-01-23: Final-final review fixes: keep delete endpoint sync, stabilize delete loading test, clear delete error on success.
+- 2026-01-23: Review loop fixes: disable edit during delete, add delete-twice 404 test, assert no navigation on delete errors.
+- 2026-01-23: Review loop fixes: prevent delete re-entry during confirmation, document delete-twice 404 AC.
+- 2026-01-23: Review loop fixes: align AC8 task and test name.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -46,7 +46,7 @@ development_status:
   2-1-project-list-create: done
   2-2-view-project-details: done
   2-3-edit-project: review
-  2-4-delete-project: backlog
+  2-4-delete-project: done
   epic-2-retrospective: optional
 
   # Epic 3: Task Management

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -72,3 +72,22 @@ def update_project(
     db.commit()
     db.refresh(project)
     return ProjectDataResponse(data=ProjectResponse.model_validate(project))
+
+
+@router.delete("/{project_id}", response_model=ProjectDataResponse)
+def delete_project(
+    project_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    project = db.query(Project).filter(Project.id == project_id).first()
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+    if project.user_id != current_user.id:
+        raise HTTPException(
+            status_code=403, detail="Not authorized to access this project"
+        )
+    response_data = ProjectResponse.model_validate(project)
+    db.delete(project)
+    db.commit()
+    return ProjectDataResponse(data=response_data)

--- a/backend/tests/api/test_projects_api.py
+++ b/backend/tests/api/test_projects_api.py
@@ -311,6 +311,100 @@ class ProjectsApiTests(unittest.TestCase):
         body = response.json()
         self.assertEqual(body["data"]["name"], "Trimmed Name")
 
+    # Story 2.4: Delete Project tests
+    def test_delete_project_removes_project_for_owner(self):
+        user = self._create_user("user@example.com", "secret123")
+        session = db.SessionLocal()
+        try:
+            project = self.Project(name="Delete Me", user_id=user.id)
+            session.add(project)
+            session.commit()
+            session.refresh(project)
+            project_id = project.id
+        finally:
+            session.close()
+
+        response = self.client.delete(
+            f"/api/projects/{project_id}",
+            headers=self._auth_header_for(user.email),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["data"]["id"], project_id)
+        self.assertEqual(body["data"]["name"], "Delete Me")
+        self.assertEqual(body["data"]["user_id"], user.id)
+        self.assertIn("created_at", body["data"])
+        self.assertIn("updated_at", body["data"])
+
+        session = db.SessionLocal()
+        try:
+            remaining = (
+                session.query(self.Project)
+                .filter(self.Project.id == project_id)
+                .first()
+            )
+        finally:
+            session.close()
+        self.assertIsNone(remaining)
+
+    def test_delete_project_returns_404_for_missing_project(self):
+        user = self._create_user("user@example.com", "secret123")
+        response = self.client.delete(
+            "/api/projects/9999",
+            headers=self._auth_header_for(user.email),
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_delete_project_returns_404_when_already_deleted_ac8(self):
+        user = self._create_user("user@example.com", "secret123")
+        session = db.SessionLocal()
+        try:
+            project = self.Project(name="Delete Twice", user_id=user.id)
+            session.add(project)
+            session.commit()
+            session.refresh(project)
+            project_id = project.id
+        finally:
+            session.close()
+
+        response = self.client.delete(
+            f"/api/projects/{project_id}",
+            headers=self._auth_header_for(user.email),
+        )
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.delete(
+            f"/api/projects/{project_id}",
+            headers=self._auth_header_for(user.email),
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_delete_project_returns_403_for_non_owner(self):
+        owner = self._create_user("owner@example.com", "secret123")
+        other = self._create_user("other@example.com", "secret123")
+        session = db.SessionLocal()
+        try:
+            project = self.Project(name="Owner Project", user_id=owner.id)
+            session.add(project)
+            session.commit()
+            session.refresh(project)
+            project_id = project.id
+        finally:
+            session.close()
+
+        response = self.client.delete(
+            f"/api/projects/{project_id}",
+            headers=self._auth_header_for(other.email),
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_delete_project_returns_401_for_unauthenticated_request(self):
+        response = self.client.delete("/api/projects/1")
+        self.assertEqual(response.status_code, 401)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -136,4 +136,5 @@ export const projectsApi = {
   get: (id: number) => api.get<ApiResponse<ProjectData>>(`/projects/${id}`),
   update: (id: number, data: UpdateProjectData) =>
     api.put<ApiResponse<ProjectData>>(`/projects/${id}`, data),
+  delete: (id: number) => api.delete<ApiResponse<ProjectData>>(`/projects/${id}`),
 };

--- a/frontend/src/pages/ProjectDetail.test.tsx
+++ b/frontend/src/pages/ProjectDetail.test.tsx
@@ -5,10 +5,21 @@ import userEvent from '@testing-library/user-event';
 import ProjectDetail from './ProjectDetail';
 
 const mockLogout = vi.fn();
+const mockNavigate = vi.fn();
 
 vi.mock('../hooks/useLogout', () => ({
   useLogout: () => ({ logout: mockLogout }),
 }));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom'
+  );
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
 
 vi.mock('../api/client', async () => {
   const actual = await vi.importActual<typeof import('../api/client')>(
@@ -19,6 +30,7 @@ vi.mock('../api/client', async () => {
     projectsApi: {
       get: vi.fn(),
       update: vi.fn(),
+      delete: vi.fn(),
     },
   };
 });
@@ -29,7 +41,9 @@ describe('ProjectDetail page', () => {
   beforeEach(() => {
     vi.mocked(projectsApi.get).mockReset();
     vi.mocked(projectsApi.update).mockReset();
+    vi.mocked(projectsApi.delete).mockReset();
     mockLogout.mockReset();
+    mockNavigate.mockReset();
   });
 
   const renderWithRoute = (id: string) =>
@@ -131,6 +145,7 @@ describe('ProjectDetail page', () => {
     renderWithRoute('1');
 
     expect(await screen.findByRole('button', { name: /edit/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
   });
 
   it('toggles edit mode when edit button clicked', async () => {
@@ -250,5 +265,183 @@ describe('ProjectDetail page', () => {
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
     expect(screen.getByText('Launch Plan')).toBeInTheDocument();
     expect(projectsApi.update).not.toHaveBeenCalled();
+  });
+
+  it('confirms delete, calls API, and navigates to projects', async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    vi.mocked(projectsApi.get).mockResolvedValue({
+      data: {
+        id: 1,
+        name: 'Launch Plan',
+        user_id: 1,
+        created_at: '2026-01-21T00:00:00Z',
+        updated_at: '2026-01-22T00:00:00Z',
+      },
+    });
+    vi.mocked(projectsApi.delete).mockResolvedValue({
+      data: {
+        id: 1,
+        name: 'Launch Plan',
+        user_id: 1,
+        created_at: '2026-01-21T00:00:00Z',
+        updated_at: '2026-01-22T00:00:00Z',
+      },
+    });
+
+    renderWithRoute('1');
+
+    const deleteButton = await screen.findByRole('button', { name: /delete/i });
+    await user.click(deleteButton);
+
+    await waitFor(() => {
+      expect(confirmSpy).toHaveBeenCalled();
+      expect(projectsApi.delete).toHaveBeenCalledWith(1);
+      expect(mockNavigate).toHaveBeenCalledWith('/projects');
+    });
+
+    confirmSpy.mockRestore();
+  });
+
+  it('cancels delete and does not call API', async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    vi.mocked(projectsApi.get).mockResolvedValue({
+      data: {
+        id: 1,
+        name: 'Launch Plan',
+        user_id: 1,
+        created_at: '2026-01-21T00:00:00Z',
+        updated_at: '2026-01-22T00:00:00Z',
+      },
+    });
+
+    renderWithRoute('1');
+
+    const deleteButton = await screen.findByRole('button', { name: /delete/i });
+    await user.click(deleteButton);
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(projectsApi.delete).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
+  });
+
+  it('disables delete button while deleting', async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    let resolveDelete: (value: { data: unknown }) => void;
+    const deletePromise = new Promise<{ data: unknown }>((resolve) => {
+      resolveDelete = resolve;
+    });
+
+    vi.mocked(projectsApi.get).mockResolvedValue({
+      data: {
+        id: 1,
+        name: 'Launch Plan',
+        user_id: 1,
+        created_at: '2026-01-21T00:00:00Z',
+        updated_at: '2026-01-22T00:00:00Z',
+      },
+    });
+    vi.mocked(projectsApi.delete).mockReturnValue(deletePromise);
+
+    renderWithRoute('1');
+
+    const deleteButton = await screen.findByRole('button', { name: /delete/i });
+    await user.click(deleteButton);
+
+    await waitFor(() => {
+      expect(confirmSpy).toHaveBeenCalled();
+      expect(deleteButton).toBeDisabled();
+      expect(deleteButton).toHaveTextContent(/deleting/i);
+    });
+
+    resolveDelete!({ data: {} });
+    confirmSpy.mockRestore();
+  });
+
+  it('shows error when delete returns 403', async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    vi.mocked(projectsApi.get).mockResolvedValue({
+      data: {
+        id: 1,
+        name: 'Launch Plan',
+        user_id: 1,
+        created_at: '2026-01-21T00:00:00Z',
+        updated_at: '2026-01-22T00:00:00Z',
+      },
+    });
+    vi.mocked(projectsApi.delete).mockRejectedValue(
+      new ApiRequestError(403, 'Forbidden')
+    );
+
+    renderWithRoute('1');
+
+    const deleteButton = await screen.findByRole('button', { name: /delete/i });
+    await user.click(deleteButton);
+
+    expect(await screen.findByText(/permission to delete/i)).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
+  });
+
+  it('shows error when delete returns 404', async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    vi.mocked(projectsApi.get).mockResolvedValue({
+      data: {
+        id: 1,
+        name: 'Launch Plan',
+        user_id: 1,
+        created_at: '2026-01-21T00:00:00Z',
+        updated_at: '2026-01-22T00:00:00Z',
+      },
+    });
+    vi.mocked(projectsApi.delete).mockRejectedValue(
+      new ApiRequestError(404, 'Project not found')
+    );
+
+    renderWithRoute('1');
+
+    const deleteButton = await screen.findByRole('button', { name: /delete/i });
+    await user.click(deleteButton);
+
+    expect(await screen.findByText(/project not found/i)).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
+  });
+
+  it('logs out when delete returns 401', async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    vi.mocked(projectsApi.get).mockResolvedValue({
+      data: {
+        id: 1,
+        name: 'Launch Plan',
+        user_id: 1,
+        created_at: '2026-01-21T00:00:00Z',
+        updated_at: '2026-01-22T00:00:00Z',
+      },
+    });
+    vi.mocked(projectsApi.delete).mockRejectedValue(
+      new ApiRequestError(401, 'Not authenticated')
+    );
+
+    renderWithRoute('1');
+
+    const deleteButton = await screen.findByRole('button', { name: /delete/i });
+    await user.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockLogout).toHaveBeenCalled();
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
   });
 });

--- a/frontend/src/pages/ProjectDetail.tsx
+++ b/frontend/src/pages/ProjectDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import Header from '../components/Header';
 import { ApiRequestError, projectsApi } from '../api/client';
 import type { ProjectData } from '../api/client';
@@ -8,16 +8,19 @@ import { useLogout } from '../hooks/useLogout';
 export default function ProjectDetail() {
   const { id } = useParams<{ id: string }>();
   const { logout } = useLogout();
+  const navigate = useNavigate();
   const userEmail = localStorage.getItem('user_email');
   const [project, setProject] = useState<ProjectData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   // Edit mode state
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState('');
   const [editError, setEditError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
     if (!id) {
@@ -34,6 +37,7 @@ export default function ProjectDetail() {
         if (!active) return;
         setProject(response.data);
         setError(null);
+        setDeleteError(null);
       })
       .catch((err) => {
         if (!active) return;
@@ -67,6 +71,7 @@ export default function ProjectDetail() {
   const handleEdit = () => {
     setEditName(project?.name ?? '');
     setEditError(null);
+    setDeleteError(null);
     setIsEditing(true);
   };
 
@@ -109,6 +114,43 @@ export default function ProjectDetail() {
       setEditError(err instanceof Error ? err.message : 'Failed to update project');
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!project) return;
+    if (deleting) return;
+    setDeleting(true);
+    const confirmed = window.confirm('Delete this project?');
+    if (!confirmed) {
+      setDeleting(false);
+      return;
+    }
+
+    setDeleteError(null);
+
+    try {
+      await projectsApi.delete(project.id);
+      setDeleteError(null);
+      navigate('/projects');
+    } catch (err) {
+      if (err instanceof ApiRequestError) {
+        if (err.status === 401) {
+          logout();
+          return;
+        }
+        if (err.status === 403) {
+          setDeleteError('You do not have permission to delete this project.');
+          return;
+        }
+        if (err.status === 404) {
+          setDeleteError('Project not found.');
+          return;
+        }
+      }
+      setDeleteError(err instanceof Error ? err.message : 'Failed to delete project');
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -168,13 +210,24 @@ export default function ProjectDetail() {
               <>
                 <div className="flex items-start justify-between">
                   <h1 className="text-2xl font-bold text-gray-900">{project.name}</h1>
-                  <button
-                    type="button"
-                    onClick={handleEdit}
-                    className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
-                  >
-                    Edit
-                  </button>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={handleEdit}
+                      disabled={deleting}
+                      className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleDelete}
+                      disabled={deleting}
+                      className="inline-flex items-center justify-center rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700"
+                    >
+                      {deleting ? 'Deleting...' : 'Delete'}
+                    </button>
+                  </div>
                 </div>
                 <div className="mt-4 space-y-2 text-sm text-gray-600">
                   <p>
@@ -198,6 +251,9 @@ export default function ProjectDetail() {
                     })}
                   </p>
                 </div>
+                {deleteError ? (
+                  <p className="mt-4 text-sm text-red-600">{deleteError}</p>
+                ) : null}
               </>
             )}
           </section>


### PR DESCRIPTION
Implements project deletion across backend and frontend with confirmation, auth/ownership checks, and robust error handling. Adds comprehensive delete tests (API + UI), including delete‑twice 404 and loading state behavior. Updates story/sprint tracking for Story 2.4.