### PR TITLE
Feature/story 3.2 Edit task titles (backend + frontend)  

### DIFF
--- a/_bmad-output/implementation-artifacts/3-2-edit-task.md
+++ b/_bmad-output/implementation-artifacts/3-2-edit-task.md
@@ -1,0 +1,397 @@
+# Story 3.2: Edit Task
+
+Status: ready-for-dev
+
+## Story
+
+As a **user**,
+I want to **edit a task's title**,
+So that **I can update task details**.
+
+## Acceptance Criteria
+
+1. **Given** I have a task in my project **When** I click an "Edit" button on the task **Then** I can edit the task title inline
+2. **Given** I am editing a task title **When** I submit a valid new title **Then** the change is persisted and the UI updates
+3. **Given** I am editing a task title **When** I submit an empty title **Then** I see a validation error
+4. **Given** I try to edit a task in a project I don't own **Then** the API returns 403 Forbidden
+5. **Given** I try to edit a task that doesn't exist **Then** the API returns 404 Not Found
+6. **Given** I am not authenticated **When** I try to edit a task **Then** the API returns 401 Unauthorized
+7. **Given** I am editing **When** I click "Cancel" **Then** the edit is discarded and the original title is shown
+8. **Given** I try to edit a task in a project that doesn't exist **Then** the API returns 404 Not Found
+
+## Tasks / Subtasks
+
+- [ ] **Task 1: Backend TaskUpdate Schema** (AC: 2, 3)
+  - [ ] Add `TaskUpdate` schema to `backend/app/schemas/task.py`
+  - [ ] Use same validation as `TaskCreate` (title: str, min_length=1, max_length=200, strip whitespace)
+  - [ ] Export from `backend/app/schemas/__init__.py`
+
+- [ ] **Task 2: Backend PUT Endpoint** (AC: 2, 3, 4, 5, 6, 8)
+  - [ ] Add `PUT /api/projects/{project_id}/tasks/{task_id}` endpoint to `backend/app/routers/tasks.py`
+  - [ ] Use `get_current_user` dependency for authentication
+  - [ ] Query project by ID, return 404 if not found
+  - [ ] Check project ownership, return 403 if not owner
+  - [ ] Query task by ID, return 404 if not found
+  - [ ] Verify task belongs to project (extra safety check)
+  - [ ] Update task title and `updated_at` timestamp
+  - [ ] Return updated task data with 200
+
+- [ ] **Task 3: Backend Testing** (AC: 2, 3, 4, 5, 6, 8)
+  - [ ] Add tests to `backend/tests/api/test_tasks_api.py`
+  - [ ] Test: PUT /projects/{pid}/tasks/{tid} updates title and returns updated task
+  - [ ] Test: PUT with empty title returns 422
+  - [ ] Test: PUT with whitespace-only title returns 422
+  - [ ] Test: PUT returns 404 for non-existent task
+  - [ ] Test: PUT returns 404 for non-existent project
+  - [ ] Test: PUT returns 403 for project not owned by user
+  - [ ] Test: PUT returns 401 for unauthenticated request
+  - [ ] Test: PUT trims whitespace from title
+
+- [ ] **Task 4: Frontend API Client** (AC: 2)
+  - [ ] Add `UpdateTaskData` interface to `frontend/src/api/client.ts`
+  - [ ] Add `update(projectId: number, taskId: number, data: UpdateTaskData)` method to `tasksApi`
+  - [ ] Returns `ApiResponse<TaskData>`
+
+- [ ] **Task 5: Edit UI for Tasks in ProjectDetail** (AC: 1, 2, 3, 7)
+  - [ ] Update `frontend/src/pages/ProjectDetail.tsx`
+  - [ ] Add edit mode state per task (track which task is being edited)
+  - [ ] Add "Edit" button on each task item
+  - [ ] Show input field with current title when in edit mode
+  - [ ] Add "Save" and "Cancel" buttons in edit mode
+  - [ ] Call `tasksApi.update()` on save
+  - [ ] Show validation error for empty title
+  - [ ] Update local tasks state on successful save
+  - [ ] Handle 403/404 errors gracefully
+  - [ ] Style with Tailwind CSS matching existing design
+
+- [ ] **Task 6: Frontend Testing** (AC: 1, 2, 3, 7)
+  - [ ] Update `frontend/src/pages/ProjectDetail.test.tsx`
+  - [ ] Test: Edit button on task toggles edit mode for that task
+  - [ ] Test: Save submits update and shows new title
+  - [ ] Test: Empty title shows validation error
+  - [ ] Test: Cancel discards changes and exits edit mode
+  - [ ] Test: Only one task can be in edit mode at a time (optional UX improvement)
+
+## Dev Notes
+
+### Architecture Compliance
+
+**Backend Structure:**
+- Schema: `backend/app/schemas/task.py` (add TaskUpdate)
+- Endpoint: `backend/app/routers/tasks.py` (add PUT endpoint)
+- Tests: `backend/tests/api/test_tasks_api.py` (add update tests)
+
+**Frontend Structure:**
+- Page: `frontend/src/pages/ProjectDetail.tsx` (add task edit functionality)
+- API: `frontend/src/api/client.ts` (add update method to tasksApi)
+- Tests: `frontend/src/pages/ProjectDetail.test.tsx` (add task edit tests)
+
+### Technical Requirements
+
+| Requirement | Implementation |
+|-------------|----------------|
+| Authentication | `get_current_user` dependency |
+| Authorization | Verify project ownership via `project.user_id == current_user.id` |
+| Nested Routes | `PUT /api/projects/{project_id}/tasks/{task_id}` |
+| Validation | Pydantic schema with min_length=1, max_length=200, strip whitespace |
+| HTTP Method | PUT for full resource update |
+| Timestamp | Auto-update `updated_at` on save |
+
+### API Endpoint Spec
+
+**PUT /api/projects/{project_id}/tasks/{task_id}** (Protected)
+
+Request Headers:
+```
+Authorization: Bearer <access_token>
+```
+
+Request Body:
+```json
+{
+  "title": "Updated Task Title"
+}
+```
+
+Success Response (200):
+```json
+{
+  "data": {
+    "id": 1,
+    "title": "Updated Task Title",
+    "is_complete": false,
+    "project_id": 1,
+    "created_at": "2026-01-23T00:00:00Z",
+    "updated_at": "2026-01-23T12:00:00Z"
+  }
+}
+```
+
+Error Response (401 - not authenticated):
+```json
+{
+  "detail": "Not authenticated"
+}
+```
+
+Error Response (403 - not owner):
+```json
+{
+  "detail": "Not authorized to access this project"
+}
+```
+
+Error Response (404 - project not found):
+```json
+{
+  "detail": "Project not found"
+}
+```
+
+Error Response (404 - task not found):
+```json
+{
+  "detail": "Task not found"
+}
+```
+
+Validation Error (422 - empty title):
+```json
+{
+  "detail": [
+    {
+      "loc": ["body", "title"],
+      "msg": "String should have at least 1 character",
+      "type": "string_too_short"
+    }
+  ]
+}
+```
+
+### Component Specifications
+
+**TaskUpdate Schema:**
+```python
+class TaskUpdate(BaseModel):
+    title: str = Field(min_length=1, max_length=200)
+
+    @field_validator("title", mode="before")
+    @classmethod
+    def title_not_blank(cls, value: str) -> str:
+        if not isinstance(value, str):
+            raise ValueError("Task title must be a string")
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("Task title cannot be blank")
+        return trimmed
+```
+
+**Backend PUT Endpoint:**
+```python
+@router.put("/{task_id}", response_model=TaskDataResponse)
+async def update_task(
+    project_id: int,
+    task_id: int,
+    task_data: TaskUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    project = await get_project_or_404(project_id, current_user, db)
+    task = await db.scalar(
+        select(Task).where(Task.id == task_id, Task.project_id == project.id)
+    )
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    task.title = task_data.title
+    await db.commit()
+    await db.refresh(task)
+    return TaskDataResponse(data=TaskResponse.model_validate(task))
+```
+
+**Frontend tasksApi update:**
+```typescript
+export interface UpdateTaskData {
+  title: string;
+}
+
+export const tasksApi = {
+  list: (projectId: number) =>
+    api.get<ApiResponse<TaskData[]>>(`/projects/${projectId}/tasks`),
+  create: (projectId: number, data: CreateTaskData) =>
+    api.post<ApiResponse<TaskData>>(`/projects/${projectId}/tasks`, data),
+  update: (projectId: number, taskId: number, data: UpdateTaskData) =>
+    api.put<ApiResponse<TaskData>>(`/projects/${projectId}/tasks/${taskId}`, data),
+};
+```
+
+**ProjectDetail.tsx Task Edit Mode Pattern:**
+```tsx
+// Add to existing state
+const [editingTaskId, setEditingTaskId] = useState<number | null>(null);
+const [editTaskTitle, setEditTaskTitle] = useState('');
+const [editTaskError, setEditTaskError] = useState<string | null>(null);
+const [savingTask, setSavingTask] = useState(false);
+
+const handleEditTask = (task: TaskData) => {
+  setEditingTaskId(task.id);
+  setEditTaskTitle(task.title);
+  setEditTaskError(null);
+};
+
+const handleCancelEditTask = () => {
+  setEditingTaskId(null);
+  setEditTaskTitle('');
+  setEditTaskError(null);
+};
+
+const handleSaveTask = async (taskId: number) => {
+  const trimmed = editTaskTitle.trim();
+  if (!trimmed) {
+    setEditTaskError('Task title is required.');
+    return;
+  }
+  if (trimmed.length > 200) {
+    setEditTaskError('Task title must be 200 characters or less.');
+    return;
+  }
+
+  setSavingTask(true);
+  try {
+    const response = await tasksApi.update(project!.id, taskId, { title: trimmed });
+    setTasks(tasks.map(t => t.id === taskId ? response.data : t));
+    setEditingTaskId(null);
+    setEditTaskTitle('');
+    setEditTaskError(null);
+  } catch (err) {
+    if (err instanceof ApiRequestError) {
+      if (err.status === 401) {
+        logout();
+        return;
+      }
+      if (err.status === 403) {
+        setEditTaskError('You do not have permission to edit this task.');
+        return;
+      }
+      if (err.status === 404) {
+        setEditTaskError('Task not found.');
+        return;
+      }
+      if (err.status === 422) {
+        setEditTaskError('Invalid task title.');
+        return;
+      }
+    }
+    setEditTaskError(err instanceof Error ? err.message : 'Failed to update task');
+  } finally {
+    setSavingTask(false);
+  }
+};
+
+// In render - Task item with edit mode:
+{tasks.map((task) => (
+  <li key={task.id} className="flex items-center gap-3 rounded-md border border-gray-200 px-4 py-3">
+    {editingTaskId === task.id ? (
+      <div className="flex flex-1 items-center gap-2">
+        <input
+          type="text"
+          value={editTaskTitle}
+          onChange={(e) => setEditTaskTitle(e.target.value)}
+          className="flex-1 rounded-md border border-gray-300 px-2 py-1 text-sm"
+          disabled={savingTask}
+        />
+        <button
+          onClick={() => handleSaveTask(task.id)}
+          disabled={savingTask}
+          className="rounded-md bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          Save
+        </button>
+        <button
+          onClick={handleCancelEditTask}
+          disabled={savingTask}
+          className="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 hover:bg-gray-50"
+        >
+          Cancel
+        </button>
+      </div>
+    ) : (
+      <>
+        <span className={`h-4 w-4 rounded-full ${task.is_complete ? 'bg-green-500' : 'bg-gray-300'}`} />
+        <span className={`flex-1 ${task.is_complete ? 'text-gray-500 line-through' : 'text-gray-900'}`}>
+          {task.title}
+        </span>
+        <button
+          onClick={() => handleEditTask(task)}
+          className="text-sm text-blue-600 hover:underline"
+        >
+          Edit
+        </button>
+      </>
+    )}
+  </li>
+))}
+{editingTaskId && editTaskError && (
+  <p className="mt-2 text-sm text-red-600">{editTaskError}</p>
+)}
+```
+
+### References
+
+**Planning Documents:**
+- [PRD: FR12](../planning-artifacts/prd.md)
+- [Architecture: Task Structure](../planning-artifacts/architecture.md)
+- [Epics: Story 3.2](../planning-artifacts/epics.md#Story-3.2-Edit-Task)
+
+**Source: Story 3.1 Implementation (Follow These!)**
+- [backend/app/routers/tasks.py](../../backend/app/routers/tasks.py) - Add PUT endpoint here
+- [backend/app/schemas/task.py](../../backend/app/schemas/task.py) - Add TaskUpdate schema here
+- [backend/tests/api/test_tasks_api.py](../../backend/tests/api/test_tasks_api.py) - Add update tests here
+- [frontend/src/api/client.ts](../../frontend/src/api/client.ts) - Add update method here
+- [frontend/src/pages/ProjectDetail.tsx](../../frontend/src/pages/ProjectDetail.tsx) - Add task edit UI here
+
+**Source: Story 2.3 Patterns (Edit Project)**
+- Same edit mode pattern with Save/Cancel buttons
+- Same validation approach (empty, whitespace, max length)
+- Same error handling pattern (401 logout, 403/404 show error)
+
+### Key Learnings from Previous Stories to Apply
+
+1. **Whitespace validation** - Strip and validate title not blank (from Story 3.1)
+2. **Consistent error handling** - Use `ApiRequestError` pattern for 401/403/404/422 (from Story 3.1)
+3. **TDD approach** - Write tests first, then implement (from Story 2.3)
+4. **Edit mode state** - Track which item is being edited, show input with Save/Cancel (from Story 2.3)
+5. **Reuse `get_project_or_404`** - Already exists in tasks.py router
+
+### Epic 2 Retrospective Action Items Applied
+
+1. **Delete operation edge cases** - Not applicable to this story (Story 3.4 will need this)
+2. **Spec-driven + TDD approach** - Continue this methodology
+
+## Dev Agent Record
+
+### Agent Model Used
+
+(To be filled by dev agent)
+
+### Implementation Plan
+
+(To be filled by dev agent)
+
+### Completion Notes List
+
+(To be filled by dev agent)
+
+### File List
+
+**To Modify:**
+- backend/app/schemas/task.py (add TaskUpdate)
+- backend/app/schemas/__init__.py (export TaskUpdate)
+- backend/app/routers/tasks.py (add PUT endpoint)
+- backend/tests/api/test_tasks_api.py (add update tests)
+- frontend/src/api/client.ts (add update method to tasksApi)
+- frontend/src/pages/ProjectDetail.tsx (add task edit UI)
+- frontend/src/pages/ProjectDetail.test.tsx (add task edit tests)
+
+### Change Log
+
+(To be filled by dev agent)

--- a/_bmad-output/implementation-artifacts/3-2-edit-task.md
+++ b/_bmad-output/implementation-artifacts/3-2-edit-task.md
@@ -1,6 +1,6 @@
 # Story 3.2: Edit Task
 
-Status: ready-for-dev
+Status: review
 
 ## Story
 
@@ -21,55 +21,55 @@ So that **I can update task details**.
 
 ## Tasks / Subtasks
 
-- [ ] **Task 1: Backend TaskUpdate Schema** (AC: 2, 3)
-  - [ ] Add `TaskUpdate` schema to `backend/app/schemas/task.py`
-  - [ ] Use same validation as `TaskCreate` (title: str, min_length=1, max_length=200, strip whitespace)
-  - [ ] Export from `backend/app/schemas/__init__.py`
+- [x] **Task 1: Backend TaskUpdate Schema** (AC: 2, 3)
+  - [x] Add `TaskUpdate` schema to `backend/app/schemas/task.py`
+  - [x] Use same validation as `TaskCreate` (title: str, min_length=1, max_length=200, strip whitespace)
+  - [x] Export from `backend/app/schemas/__init__.py`
 
-- [ ] **Task 2: Backend PUT Endpoint** (AC: 2, 3, 4, 5, 6, 8)
-  - [ ] Add `PUT /api/projects/{project_id}/tasks/{task_id}` endpoint to `backend/app/routers/tasks.py`
-  - [ ] Use `get_current_user` dependency for authentication
-  - [ ] Query project by ID, return 404 if not found
-  - [ ] Check project ownership, return 403 if not owner
-  - [ ] Query task by ID, return 404 if not found
-  - [ ] Verify task belongs to project (extra safety check)
-  - [ ] Update task title and `updated_at` timestamp
-  - [ ] Return updated task data with 200
+- [x] **Task 2: Backend PUT Endpoint** (AC: 2, 3, 4, 5, 6, 8)
+  - [x] Add `PUT /api/projects/{project_id}/tasks/{task_id}` endpoint to `backend/app/routers/tasks.py`
+  - [x] Use `get_current_user` dependency for authentication
+  - [x] Query project by ID, return 404 if not found
+  - [x] Check project ownership, return 403 if not owner
+  - [x] Query task by ID, return 404 if not found
+  - [x] Verify task belongs to project (extra safety check)
+  - [x] Update task title and `updated_at` timestamp
+  - [x] Return updated task data with 200
 
-- [ ] **Task 3: Backend Testing** (AC: 2, 3, 4, 5, 6, 8)
-  - [ ] Add tests to `backend/tests/api/test_tasks_api.py`
-  - [ ] Test: PUT /projects/{pid}/tasks/{tid} updates title and returns updated task
-  - [ ] Test: PUT with empty title returns 422
-  - [ ] Test: PUT with whitespace-only title returns 422
-  - [ ] Test: PUT returns 404 for non-existent task
-  - [ ] Test: PUT returns 404 for non-existent project
-  - [ ] Test: PUT returns 403 for project not owned by user
-  - [ ] Test: PUT returns 401 for unauthenticated request
-  - [ ] Test: PUT trims whitespace from title
+- [x] **Task 3: Backend Testing** (AC: 2, 3, 4, 5, 6, 8)
+  - [x] Add tests to `backend/tests/api/test_tasks_api.py`
+  - [x] Test: PUT /projects/{pid}/tasks/{tid} updates title and returns updated task
+  - [x] Test: PUT with empty title returns 422
+  - [x] Test: PUT with whitespace-only title returns 422
+  - [x] Test: PUT returns 404 for non-existent task
+  - [x] Test: PUT returns 404 for non-existent project
+  - [x] Test: PUT returns 403 for project not owned by user
+  - [x] Test: PUT returns 401 for unauthenticated request
+  - [x] Test: PUT trims whitespace from title
 
-- [ ] **Task 4: Frontend API Client** (AC: 2)
-  - [ ] Add `UpdateTaskData` interface to `frontend/src/api/client.ts`
-  - [ ] Add `update(projectId: number, taskId: number, data: UpdateTaskData)` method to `tasksApi`
-  - [ ] Returns `ApiResponse<TaskData>`
+- [x] **Task 4: Frontend API Client** (AC: 2)
+  - [x] Add `UpdateTaskData` interface to `frontend/src/api/client.ts`
+  - [x] Add `update(projectId: number, taskId: number, data: UpdateTaskData)` method to `tasksApi`
+  - [x] Returns `ApiResponse<TaskData>`
 
-- [ ] **Task 5: Edit UI for Tasks in ProjectDetail** (AC: 1, 2, 3, 7)
-  - [ ] Update `frontend/src/pages/ProjectDetail.tsx`
-  - [ ] Add edit mode state per task (track which task is being edited)
-  - [ ] Add "Edit" button on each task item
-  - [ ] Show input field with current title when in edit mode
-  - [ ] Add "Save" and "Cancel" buttons in edit mode
-  - [ ] Call `tasksApi.update()` on save
-  - [ ] Show validation error for empty title
-  - [ ] Update local tasks state on successful save
-  - [ ] Handle 403/404 errors gracefully
-  - [ ] Style with Tailwind CSS matching existing design
+- [x] **Task 5: Edit UI for Tasks in ProjectDetail** (AC: 1, 2, 3, 7)
+  - [x] Update `frontend/src/pages/ProjectDetail.tsx`
+  - [x] Add edit mode state per task (track which task is being edited)
+  - [x] Add "Edit" button on each task item
+  - [x] Show input field with current title when in edit mode
+  - [x] Add "Save" and "Cancel" buttons in edit mode
+  - [x] Call `tasksApi.update()` on save
+  - [x] Show validation error for empty title
+  - [x] Update local tasks state on successful save
+  - [x] Handle 403/404 errors gracefully
+  - [x] Style with Tailwind CSS matching existing design
 
-- [ ] **Task 6: Frontend Testing** (AC: 1, 2, 3, 7)
-  - [ ] Update `frontend/src/pages/ProjectDetail.test.tsx`
-  - [ ] Test: Edit button on task toggles edit mode for that task
-  - [ ] Test: Save submits update and shows new title
-  - [ ] Test: Empty title shows validation error
-  - [ ] Test: Cancel discards changes and exits edit mode
+- [x] **Task 6: Frontend Testing** (AC: 1, 2, 3, 7)
+  - [x] Update `frontend/src/pages/ProjectDetail.test.tsx`
+  - [x] Test: Edit button on task toggles edit mode for that task
+  - [x] Test: Save submits update and shows new title
+  - [x] Test: Empty title shows validation error
+  - [x] Test: Cancel discards changes and exits edit mode
   - [ ] Test: Only one task can be in edit mode at a time (optional UX improvement)
 
 ## Dev Notes
@@ -371,15 +371,26 @@ const handleSaveTask = async (taskId: number) => {
 
 ### Agent Model Used
 
-(To be filled by dev agent)
+Codex (GPT-5)
 
 ### Implementation Plan
 
-(To be filled by dev agent)
+1. Add TaskUpdate schema + unit tests for validation rules.
+2. Add PUT endpoint with auth/ownership checks and update behavior.
+3. Add backend API tests for update scenarios (success + error cases).
+4. Add frontend API client update method.
+5. Implement task inline edit UI with validation + error handling.
+6. Add frontend tests for edit flows; run full test suite.
 
 ### Completion Notes List
 
-(To be filled by dev agent)
+- Added `TaskUpdate` schema with shared validation behavior and unit tests for update validation.
+- Implemented task update endpoint with ownership checks and title trimming.
+- Added API tests covering update success and error cases.
+- Added task update API client, inline edit UI, and frontend edit tests.
+- Resolved frontend lint issues in route guards and projects list.
+- Added update error-state tests and backend cross-project update coverage.
+- Tests run: `python -m unittest backend.tests.unit.test_task_schema`, `python -m unittest backend.tests.api.test_tasks_api`, `npm test -- --run src/pages/ProjectDetail.test.tsx`, `scripts/windows/run-backend-tests.ps1`, `scripts/windows/run-frontend-tests.ps1`, `npm run lint`, `python -m unittest backend.tests.api.test_tasks_api.TasksApiTests.test_update_task_returns_404_when_task_not_in_project`
 
 ### File List
 
@@ -392,6 +403,22 @@ const handleSaveTask = async (taskId: number) => {
 - frontend/src/pages/ProjectDetail.tsx (add task edit UI)
 - frontend/src/pages/ProjectDetail.test.tsx (add task edit tests)
 
+**Modified:**
+- backend/app/schemas/task.py
+- backend/app/schemas/__init__.py
+- backend/tests/unit/test_task_schema.py
+- backend/app/routers/tasks.py
+- backend/tests/api/test_tasks_api.py
+- frontend/src/api/client.ts
+- frontend/src/components/ProtectedRoute.tsx
+- frontend/src/components/PublicRoute.tsx
+- frontend/src/pages/ProjectDetail.tsx
+- frontend/src/pages/ProjectDetail.test.tsx
+- frontend/src/pages/Projects.tsx
+
 ### Change Log
 
-(To be filled by dev agent)
+- 2026-01-23: Added TaskUpdate schema and validation unit tests.
+- 2026-01-23: Added task update endpoint and API tests.
+- 2026-01-23: Added task edit UI, API client update method, and frontend tests.
+- 2026-01-23: Fixed frontend lint warnings in auth routes and projects list.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -52,7 +52,7 @@ development_status:
   # Epic 3: Task Management
   epic-3: in-progress
   3-1-view-tasks-create: done
-  3-2-edit-task: ready-for-dev
+  3-2-edit-task: review
   3-3-toggle-task-status: backlog
   3-4-delete-task: backlog
   epic-3-retrospective: optional

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -52,7 +52,7 @@ development_status:
   # Epic 3: Task Management
   epic-3: in-progress
   3-1-view-tasks-create: done
-  3-2-edit-task: backlog
+  3-2-edit-task: ready-for-dev
   3-3-toggle-task-status: backlog
   3-4-delete-task: backlog
   epic-3-retrospective: optional

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -6,7 +8,13 @@ from ..database import get_db
 from ..models.project import Project
 from ..models.task import Task
 from ..models.user import User
-from ..schemas.task import TaskCreate, TaskDataResponse, TaskListResponse, TaskResponse
+from ..schemas.task import (
+    TaskCreate,
+    TaskDataResponse,
+    TaskListResponse,
+    TaskResponse,
+    TaskUpdate,
+)
 from ..utils.auth import get_current_user
 
 router = APIRouter(prefix="/projects/{project_id}/tasks", tags=["tasks"])
@@ -51,6 +59,27 @@ async def create_task(
     project = await get_project_or_404(project_id, current_user, db)
     task = Task(title=task_data.title, project_id=project.id)
     db.add(task)
+    await db.commit()
+    await db.refresh(task)
+    return TaskDataResponse(data=TaskResponse.model_validate(task))
+
+
+@router.put("/{task_id}", response_model=TaskDataResponse)
+async def update_task(
+    project_id: int,
+    task_id: int,
+    task_data: TaskUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    project = await get_project_or_404(project_id, current_user, db)
+    task = await db.scalar(select(Task).where(Task.id == task_id))
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    if task.project_id != project.id:
+        raise HTTPException(status_code=404, detail="Task not found")
+    task.title = task_data.title
+    task.updated_at = datetime.now(timezone.utc)
     await db.commit()
     await db.refresh(task)
     return TaskDataResponse(data=TaskResponse.model_validate(task))

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -5,7 +5,7 @@ from .project import (
     ProjectResponse,
     ProjectUpdate,
 )
-from .task import TaskCreate, TaskDataResponse, TaskListResponse, TaskResponse
+from .task import TaskCreate, TaskDataResponse, TaskListResponse, TaskResponse, TaskUpdate
 from .user import UserCreate, UserResponse
 
 __all__ = [
@@ -18,6 +18,7 @@ __all__ = [
     "TaskDataResponse",
     "TaskListResponse",
     "TaskResponse",
+    "TaskUpdate",
     "UserCreate",
     "UserResponse",
 ]

--- a/backend/app/schemas/task.py
+++ b/backend/app/schemas/task.py
@@ -17,6 +17,20 @@ class TaskCreate(BaseModel):
         return trimmed
 
 
+class TaskUpdate(BaseModel):
+    title: str = Field(min_length=1, max_length=200)
+
+    @field_validator("title", mode="before")
+    @classmethod
+    def title_not_blank(cls, value: str) -> str:
+        if not isinstance(value, str):
+            raise ValueError("Task title must be a string")
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("Task title cannot be blank")
+        return trimmed
+
+
 class TaskResponse(BaseModel):
     id: int
     title: str

--- a/backend/tests/api/test_tasks_api.py
+++ b/backend/tests/api/test_tasks_api.py
@@ -88,6 +88,15 @@ class TasksApiTests(unittest.TestCase):
         await session.refresh(project)
         return project
 
+    async def _create_task(
+        self, session: AsyncSession, project_id: int, title: str = "Task"
+    ):
+        task = self.Task(title=title, project_id=project_id)
+        session.add(task)
+        await session.commit()
+        await session.refresh(task)
+        return task
+
     def _auth_header_for(self, email: str):
         from backend.app.utils.auth import create_access_token
 
@@ -315,6 +324,142 @@ class TasksApiTests(unittest.TestCase):
             "/api/projects/1/tasks",
             json={"title": "No Auth"},
         )
+        self.assertEqual(response.status_code, 401)
+
+    def test_update_task_updates_title_and_trims(self):
+        async def setup():
+            async with db.SessionLocal() as session:
+                user = await self._create_user(session, "user@example.com", "secret123")
+                project = await self._create_project(session, user.id, name="Tasks Project")
+                task = await self._create_task(session, project.id, title="Original")
+                return user, project, task
+
+        user, project, task = asyncio.run(setup())
+
+        response = self.client.put(
+            f"/api/projects/{project.id}/tasks/{task.id}",
+            json={"title": "  Updated  "},
+            headers=self._auth_header_for(user.email),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()["data"]
+        self.assertEqual(body["title"], "Updated")
+        self.assertEqual(body["project_id"], project.id)
+
+    def test_update_task_empty_title_returns_422(self):
+        async def setup():
+            async with db.SessionLocal() as session:
+                user = await self._create_user(session, "user@example.com", "secret123")
+                project = await self._create_project(session, user.id, name="Tasks Project")
+                task = await self._create_task(session, project.id, title="Original")
+                return user, project, task
+
+        user, project, task = asyncio.run(setup())
+
+        response = self.client.put(
+            f"/api/projects/{project.id}/tasks/{task.id}",
+            json={"title": ""},
+            headers=self._auth_header_for(user.email),
+        )
+
+        self.assertEqual(response.status_code, 422)
+
+    def test_update_task_whitespace_title_returns_422(self):
+        async def setup():
+            async with db.SessionLocal() as session:
+                user = await self._create_user(session, "user@example.com", "secret123")
+                project = await self._create_project(session, user.id, name="Tasks Project")
+                task = await self._create_task(session, project.id, title="Original")
+                return user, project, task
+
+        user, project, task = asyncio.run(setup())
+
+        response = self.client.put(
+            f"/api/projects/{project.id}/tasks/{task.id}",
+            json={"title": "   "},
+            headers=self._auth_header_for(user.email),
+        )
+
+        self.assertEqual(response.status_code, 422)
+
+    def test_update_task_returns_404_for_missing_task(self):
+        async def setup():
+            async with db.SessionLocal() as session:
+                user = await self._create_user(session, "user@example.com", "secret123")
+                project = await self._create_project(session, user.id, name="Tasks Project")
+                return user, project
+
+        user, project = asyncio.run(setup())
+
+        response = self.client.put(
+            f"/api/projects/{project.id}/tasks/9999",
+            json={"title": "Update"},
+            headers=self._auth_header_for(user.email),
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_update_task_returns_404_when_task_not_in_project(self):
+        async def setup():
+            async with db.SessionLocal() as session:
+                user = await self._create_user(session, "user@example.com", "secret123")
+                project = await self._create_project(session, user.id, name="Project A")
+                other_project = await self._create_project(session, user.id, name="Project B")
+                task = await self._create_task(session, other_project.id, title="Other task")
+                return user, project, task
+
+        user, project, task = asyncio.run(setup())
+
+        response = self.client.put(
+            f"/api/projects/{project.id}/tasks/{task.id}",
+            json={"title": "Update"},
+            headers=self._auth_header_for(user.email),
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_update_task_returns_404_for_missing_project(self):
+        async def setup():
+            async with db.SessionLocal() as session:
+                user = await self._create_user(session, "user@example.com", "secret123")
+                return user
+
+        user = asyncio.run(setup())
+
+        response = self.client.put(
+            "/api/projects/9999/tasks/1",
+            json={"title": "Update"},
+            headers=self._auth_header_for(user.email),
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_update_task_returns_403_for_non_owner(self):
+        async def setup():
+            async with db.SessionLocal() as session:
+                owner = await self._create_user(session, "owner@example.com", "secret123")
+                other = await self._create_user(session, "other@example.com", "secret123")
+                project = await self._create_project(session, owner.id, name="Owner Project")
+                task = await self._create_task(session, project.id, title="Original")
+                return owner, other, project, task
+
+        owner, other, project, task = asyncio.run(setup())
+
+        response = self.client.put(
+            f"/api/projects/{project.id}/tasks/{task.id}",
+            json={"title": "Update"},
+            headers=self._auth_header_for(other.email),
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_update_task_returns_401_for_unauthenticated(self):
+        response = self.client.put(
+            "/api/projects/1/tasks/1",
+            json={"title": "No Auth"},
+        )
+
         self.assertEqual(response.status_code, 401)
 
 

--- a/backend/tests/unit/test_task_schema.py
+++ b/backend/tests/unit/test_task_schema.py
@@ -2,7 +2,7 @@ import unittest
 
 from pydantic import ValidationError
 
-from backend.app.schemas.task import TaskCreate
+from backend.app.schemas.task import TaskCreate, TaskUpdate
 
 
 class TaskSchemaTests(unittest.TestCase):
@@ -25,6 +25,26 @@ class TaskSchemaTests(unittest.TestCase):
     def test_task_create_rejects_non_string_title(self):
         with self.assertRaises(ValidationError):
             TaskCreate(title=123)
+
+    def test_task_update_requires_title(self):
+        with self.assertRaises(ValidationError):
+            TaskUpdate(title="")
+
+    def test_task_update_rejects_whitespace_only_title(self):
+        with self.assertRaises(ValidationError):
+            TaskUpdate(title="   ")
+
+    def test_task_update_rejects_too_long_title(self):
+        with self.assertRaises(ValidationError):
+            TaskUpdate(title="x" * 201)
+
+    def test_task_update_trims_title_before_length_check(self):
+        task = TaskUpdate(title="  Trimmed  ")
+        self.assertEqual(task.title, "Trimmed")
+
+    def test_task_update_rejects_non_string_title(self):
+        with self.assertRaises(ValidationError):
+            TaskUpdate(title=123)
 
 
 if __name__ == "__main__":

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -130,6 +130,10 @@ export interface CreateTaskData {
   title: string;
 }
 
+export interface UpdateTaskData {
+  title: string;
+}
+
 export const authApi = {
   register: (data: RegisterData) =>
     api.post<ApiResponse<UserData>>('/auth/register', data),
@@ -157,4 +161,9 @@ export const tasksApi = {
     api.get<ApiResponse<TaskData[]>>(`/projects/${projectId}/tasks`),
   create: (projectId: number, data: CreateTaskData) =>
     api.post<ApiResponse<TaskData>>(`/projects/${projectId}/tasks`, data),
+  update: (projectId: number, taskId: number, data: UpdateTaskData) =>
+    api.put<ApiResponse<TaskData>>(
+      `/projects/${projectId}/tasks/${taskId}`,
+      data
+    ),
 };

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -30,12 +30,11 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
   const [status, setStatus] = useState<'checking' | 'allowed' | 'denied'>(() => {
     return !token || !isTokenValid(token) ? 'denied' : 'checking';
   });
+  const tokenValid = isTokenValid(token);
+  const effectiveStatus = tokenValid ? status : 'denied';
 
   useEffect(() => {
-    if (!token || !isTokenValid(token)) {
-      setStatus('denied');
-      return;
-    }
+    if (!tokenValid) return;
     let active = true;
     authApi.me()
       .then(() => {
@@ -57,13 +56,13 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
     return () => {
       active = false;
     };
-  }, [token]);
+  }, [tokenValid]);
 
-  if (status === 'checking') {
+  if (effectiveStatus === 'checking') {
     return null;
   }
 
-  if (status === 'denied') {
+  if (effectiveStatus === 'denied') {
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
 

--- a/frontend/src/components/PublicRoute.tsx
+++ b/frontend/src/components/PublicRoute.tsx
@@ -29,12 +29,11 @@ export default function PublicRoute({ children }: PublicRouteProps) {
   const [status, setStatus] = useState<'checking' | 'guest' | 'authed'>(() => {
     return !token || !isTokenValid(token) ? 'guest' : 'checking';
   });
+  const tokenValid = isTokenValid(token);
+  const effectiveStatus = tokenValid ? status : 'guest';
 
   useEffect(() => {
-    if (!token || !isTokenValid(token)) {
-      setStatus('guest');
-      return;
-    }
+    if (!tokenValid) return;
     let active = true;
     authApi.me()
       .then(() => {
@@ -56,13 +55,13 @@ export default function PublicRoute({ children }: PublicRouteProps) {
     return () => {
       active = false;
     };
-  }, [token]);
+  }, [tokenValid]);
 
-  if (status === 'checking') {
+  if (effectiveStatus === 'checking') {
     return null;
   }
 
-  if (status === 'authed') {
+  if (effectiveStatus === 'authed') {
     return <Navigate to="/dashboard" replace />;
   }
 

--- a/frontend/src/hooks/useLogout.ts
+++ b/frontend/src/hooks/useLogout.ts
@@ -1,10 +1,11 @@
+import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { authApi } from '../api/client';
 
 export function useLogout() {
   const navigate = useNavigate();
 
-  const logout = async () => {
+  const logout = useCallback(async () => {
     const refreshToken = localStorage.getItem('refresh_token');
     try {
       if (refreshToken) {
@@ -18,7 +19,7 @@ export function useLogout() {
       localStorage.removeItem('user_email');
       navigate('/login');
     }
-  };
+  }, [navigate]);
 
   return { logout };
 }

--- a/frontend/src/pages/ProjectDetail.test.tsx
+++ b/frontend/src/pages/ProjectDetail.test.tsx
@@ -35,6 +35,7 @@ vi.mock('../api/client', async () => {
     tasksApi: {
       list: vi.fn(),
       create: vi.fn(),
+      update: vi.fn(),
     },
   };
 });
@@ -48,6 +49,7 @@ describe('ProjectDetail page', () => {
     vi.mocked(projectsApi.delete).mockReset();
     vi.mocked(tasksApi.list).mockReset();
     vi.mocked(tasksApi.create).mockReset();
+    vi.mocked(tasksApi.update).mockReset();
     mockLogout.mockReset();
     mockNavigate.mockReset();
     vi.mocked(tasksApi.list).mockResolvedValue({ data: [] });
@@ -816,5 +818,365 @@ describe('ProjectDetail page', () => {
     await waitFor(() => {
       expect(mockLogout).toHaveBeenCalled();
     });
+  });
+
+  // Story 3.2: Edit Task
+
+  it('shows edit controls for a task when edit clicked', async () => {
+    const user = userEvent.setup();
+    vi.mocked(projectsApi.get).mockResolvedValue({
+      data: {
+        id: 1,
+        name: 'Launch Plan',
+        user_id: 1,
+        created_at: '2026-01-21T00:00:00Z',
+        updated_at: '2026-01-22T00:00:00Z',
+      },
+    });
+    vi.mocked(tasksApi.list).mockResolvedValue({
+      data: [
+        {
+          id: 10,
+          title: 'Design flows',
+          is_complete: false,
+          project_id: 1,
+          created_at: '2026-01-23T00:00:00Z',
+          updated_at: '2026-01-23T00:00:00Z',
+        },
+      ],
+    });
+
+    renderWithRoute('1');
+
+    const editButton = await screen.findByRole('button', {
+      name: /edit task/i,
+    });
+    await user.click(editButton);
+
+    expect(screen.getByLabelText(/edit task title/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it('saves task title updates and exits edit mode', async () => {
+    const user = userEvent.setup();
+    vi.mocked(projectsApi.get).mockResolvedValue({
+      data: {
+        id: 1,
+        name: 'Launch Plan',
+        user_id: 1,
+        created_at: '2026-01-21T00:00:00Z',
+        updated_at: '2026-01-22T00:00:00Z',
+      },
+    });
+    vi.mocked(tasksApi.list).mockResolvedValue({
+      data: [
+        {
+          id: 10,
+          title: 'Design flows',
+          is_complete: false,
+          project_id: 1,
+          created_at: '2026-01-23T00:00:00Z',
+          updated_at: '2026-01-23T00:00:00Z',
+        },
+      ],
+    });
+    vi.mocked(tasksApi.update).mockResolvedValue({
+      data: {
+        id: 10,
+        title: 'Updated flows',
+        is_complete: false,
+        project_id: 1,
+        created_at: '2026-01-23T00:00:00Z',
+        updated_at: '2026-01-24T00:00:00Z',
+      },
+    });
+
+    renderWithRoute('1');
+
+    const editButton = await screen.findByRole('button', {
+      name: /edit task/i,
+    });
+    await user.click(editButton);
+
+    const input = screen.getByLabelText(/edit task title/i);
+    await user.clear(input);
+    await user.type(input, '  Updated flows  ');
+
+    const saveButton = screen.getByRole('button', { name: /save/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(tasksApi.update).toHaveBeenCalledWith(1, 10, {
+        title: 'Updated flows',
+      });
+    });
+
+    expect(await screen.findByText('Updated flows')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /save/i })).not.toBeInTheDocument();
+  });
+
+  it('shows validation error for empty task title and does not submit', async () => {
+    const user = userEvent.setup();
+    vi.mocked(projectsApi.get).mockResolvedValue({
+      data: {
+        id: 1,
+        name: 'Launch Plan',
+        user_id: 1,
+        created_at: '2026-01-21T00:00:00Z',
+        updated_at: '2026-01-22T00:00:00Z',
+      },
+    });
+    vi.mocked(tasksApi.list).mockResolvedValue({
+      data: [
+        {
+          id: 10,
+          title: 'Design flows',
+          is_complete: false,
+          project_id: 1,
+          created_at: '2026-01-23T00:00:00Z',
+          updated_at: '2026-01-23T00:00:00Z',
+        },
+      ],
+    });
+
+    renderWithRoute('1');
+
+    const editButton = await screen.findByRole('button', {
+      name: /edit task/i,
+    });
+    await user.click(editButton);
+
+    const input = screen.getByLabelText(/edit task title/i);
+    await user.clear(input);
+
+    const saveButton = screen.getByRole('button', { name: /save/i });
+    await user.click(saveButton);
+
+    expect(await screen.findByText(/task title is required/i)).toBeInTheDocument();
+    expect(tasksApi.update).not.toHaveBeenCalled();
+  });
+
+  it('shows error when task update returns 403', async () => {
+    const user = userEvent.setup();
+    vi.mocked(projectsApi.get).mockResolvedValue({
+      data: {
+        id: 1,
+        name: 'Launch Plan',
+        user_id: 1,
+        created_at: '2026-01-21T00:00:00Z',
+        updated_at: '2026-01-22T00:00:00Z',
+      },
+    });
+    vi.mocked(tasksApi.list).mockResolvedValue({
+      data: [
+        {
+          id: 10,
+          title: 'Design flows',
+          is_complete: false,
+          project_id: 1,
+          created_at: '2026-01-23T00:00:00Z',
+          updated_at: '2026-01-23T00:00:00Z',
+        },
+      ],
+    });
+    vi.mocked(tasksApi.update).mockRejectedValue(
+      new ApiRequestError(403, 'Forbidden')
+    );
+
+    renderWithRoute('1');
+
+    const editButton = await screen.findByRole('button', {
+      name: /edit task/i,
+    });
+    await user.click(editButton);
+
+    const input = screen.getByLabelText(/edit task title/i);
+    await user.clear(input);
+    await user.type(input, 'Updated');
+
+    const saveButton = screen.getByRole('button', { name: /save/i });
+    await user.click(saveButton);
+
+    expect(
+      await screen.findByText(/permission to edit this task/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows error when task update returns 404', async () => {
+    const user = userEvent.setup();
+    vi.mocked(projectsApi.get).mockResolvedValue({
+      data: {
+        id: 1,
+        name: 'Launch Plan',
+        user_id: 1,
+        created_at: '2026-01-21T00:00:00Z',
+        updated_at: '2026-01-22T00:00:00Z',
+      },
+    });
+    vi.mocked(tasksApi.list).mockResolvedValue({
+      data: [
+        {
+          id: 10,
+          title: 'Design flows',
+          is_complete: false,
+          project_id: 1,
+          created_at: '2026-01-23T00:00:00Z',
+          updated_at: '2026-01-23T00:00:00Z',
+        },
+      ],
+    });
+    vi.mocked(tasksApi.update).mockRejectedValue(
+      new ApiRequestError(404, 'Task not found')
+    );
+
+    renderWithRoute('1');
+
+    const editButton = await screen.findByRole('button', {
+      name: /edit task/i,
+    });
+    await user.click(editButton);
+
+    const input = screen.getByLabelText(/edit task title/i);
+    await user.clear(input);
+    await user.type(input, 'Updated');
+
+    const saveButton = screen.getByRole('button', { name: /save/i });
+    await user.click(saveButton);
+
+    expect(await screen.findByText(/task not found/i)).toBeInTheDocument();
+  });
+
+  it('logs out when task update returns 401', async () => {
+    const user = userEvent.setup();
+    vi.mocked(projectsApi.get).mockResolvedValue({
+      data: {
+        id: 1,
+        name: 'Launch Plan',
+        user_id: 1,
+        created_at: '2026-01-21T00:00:00Z',
+        updated_at: '2026-01-22T00:00:00Z',
+      },
+    });
+    vi.mocked(tasksApi.list).mockResolvedValue({
+      data: [
+        {
+          id: 10,
+          title: 'Design flows',
+          is_complete: false,
+          project_id: 1,
+          created_at: '2026-01-23T00:00:00Z',
+          updated_at: '2026-01-23T00:00:00Z',
+        },
+      ],
+    });
+    vi.mocked(tasksApi.update).mockRejectedValue(
+      new ApiRequestError(401, 'Not authenticated')
+    );
+
+    renderWithRoute('1');
+
+    const editButton = await screen.findByRole('button', {
+      name: /edit task/i,
+    });
+    await user.click(editButton);
+
+    const input = screen.getByLabelText(/edit task title/i);
+    await user.clear(input);
+    await user.type(input, 'Updated');
+
+    const saveButton = screen.getByRole('button', { name: /save/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockLogout).toHaveBeenCalled();
+    });
+  });
+
+  it('shows error when task update returns 422', async () => {
+    const user = userEvent.setup();
+    vi.mocked(projectsApi.get).mockResolvedValue({
+      data: {
+        id: 1,
+        name: 'Launch Plan',
+        user_id: 1,
+        created_at: '2026-01-21T00:00:00Z',
+        updated_at: '2026-01-22T00:00:00Z',
+      },
+    });
+    vi.mocked(tasksApi.list).mockResolvedValue({
+      data: [
+        {
+          id: 10,
+          title: 'Design flows',
+          is_complete: false,
+          project_id: 1,
+          created_at: '2026-01-23T00:00:00Z',
+          updated_at: '2026-01-23T00:00:00Z',
+        },
+      ],
+    });
+    vi.mocked(tasksApi.update).mockRejectedValue(
+      new ApiRequestError(422, 'Invalid')
+    );
+
+    renderWithRoute('1');
+
+    const editButton = await screen.findByRole('button', {
+      name: /edit task/i,
+    });
+    await user.click(editButton);
+
+    const input = screen.getByLabelText(/edit task title/i);
+    await user.clear(input);
+    await user.type(input, 'Updated');
+
+    const saveButton = screen.getByRole('button', { name: /save/i });
+    await user.click(saveButton);
+
+    expect(await screen.findByText(/invalid task title/i)).toBeInTheDocument();
+  });
+
+  it('cancels task edit and restores original title', async () => {
+    const user = userEvent.setup();
+    vi.mocked(projectsApi.get).mockResolvedValue({
+      data: {
+        id: 1,
+        name: 'Launch Plan',
+        user_id: 1,
+        created_at: '2026-01-21T00:00:00Z',
+        updated_at: '2026-01-22T00:00:00Z',
+      },
+    });
+    vi.mocked(tasksApi.list).mockResolvedValue({
+      data: [
+        {
+          id: 10,
+          title: 'Design flows',
+          is_complete: false,
+          project_id: 1,
+          created_at: '2026-01-23T00:00:00Z',
+          updated_at: '2026-01-23T00:00:00Z',
+        },
+      ],
+    });
+
+    renderWithRoute('1');
+
+    const editButton = await screen.findByRole('button', {
+      name: /edit task/i,
+    });
+    await user.click(editButton);
+
+    const input = screen.getByLabelText(/edit task title/i);
+    await user.clear(input);
+    await user.type(input, 'Changed');
+
+    const cancelButton = screen.getByRole('button', { name: /cancel/i });
+    await user.click(cancelButton);
+
+    expect(screen.queryByDisplayValue('Changed')).not.toBeInTheDocument();
+    expect(await screen.findByText('Design flows')).toBeInTheDocument();
+    expect(tasksApi.update).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/ProjectDetail.tsx
+++ b/frontend/src/pages/ProjectDetail.tsx
@@ -20,6 +20,10 @@ export default function ProjectDetail() {
   const [taskError, setTaskError] = useState<string | null>(null);
   const [newTaskTitle, setNewTaskTitle] = useState('');
   const [creatingTask, setCreatingTask] = useState(false);
+  const [editingTaskId, setEditingTaskId] = useState<number | null>(null);
+  const [editTaskTitle, setEditTaskTitle] = useState('');
+  const [editTaskError, setEditTaskError] = useState<string | null>(null);
+  const [savingTask, setSavingTask] = useState(false);
 
   // Edit mode state
   const [isEditing, setIsEditing] = useState(false);
@@ -251,6 +255,73 @@ export default function ProjectDetail() {
     }
   };
 
+  const handleEditTask = (task: TaskData) => {
+    if (savingTask) return;
+    setEditingTaskId(task.id);
+    setEditTaskTitle(task.title);
+    setEditTaskError(null);
+  };
+
+  const handleCancelEditTask = () => {
+    setEditingTaskId(null);
+    setEditTaskTitle('');
+    setEditTaskError(null);
+  };
+
+  const handleSaveTask = async (taskId: number) => {
+    if (!project) return;
+    if (savingTask) return;
+
+    const trimmed = editTaskTitle.trim();
+    if (!trimmed) {
+      setEditTaskError('Task title is required.');
+      return;
+    }
+    if (trimmed.length > 200) {
+      setEditTaskError('Task title must be 200 characters or less.');
+      return;
+    }
+
+    setSavingTask(true);
+    setEditTaskError(null);
+
+    try {
+      const response = await tasksApi.update(project.id, taskId, {
+        title: trimmed,
+      });
+      setTasks((current) =>
+        current.map((task) => (task.id === taskId ? response.data : task))
+      );
+      setEditingTaskId(null);
+      setEditTaskTitle('');
+      setEditTaskError(null);
+    } catch (err) {
+      if (err instanceof ApiRequestError) {
+        if (err.status === 401) {
+          logout();
+          return;
+        }
+        if (err.status === 403) {
+          setEditTaskError('You do not have permission to edit this task.');
+          return;
+        }
+        if (err.status === 404) {
+          setEditTaskError('Task not found.');
+          return;
+        }
+        if (err.status === 422) {
+          setEditTaskError('Invalid task title.');
+          return;
+        }
+      }
+      setEditTaskError(
+        err instanceof Error ? err.message : 'Failed to update task'
+      );
+    } finally {
+      setSavingTask(false);
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gray-100">
       <Header onLogout={logout} userEmail={userEmail} />
@@ -391,20 +462,69 @@ export default function ProjectDetail() {
                       key={task.id}
                       className="flex items-center gap-3 rounded-md border border-gray-200 px-4 py-3"
                     >
-                      <span
-                        className={`h-3 w-3 rounded-full ${
-                          task.is_complete ? 'bg-green-500' : 'bg-gray-300'
-                        }`}
-                      />
-                      <span
-                        className={
-                          task.is_complete
-                            ? 'text-gray-500 line-through'
-                            : 'text-gray-900'
-                        }
-                      >
-                        {task.title}
-                      </span>
+                      {editingTaskId === task.id ? (
+                        <div className="flex w-full flex-col gap-2">
+                          <div className="flex w-full items-center gap-2">
+                            <input
+                              type="text"
+                              value={editTaskTitle}
+                              onChange={(event) =>
+                                setEditTaskTitle(event.target.value)
+                              }
+                              className="flex-1 rounded-md border border-gray-300 px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                              disabled={savingTask}
+                              aria-label="Edit task title"
+                            />
+                            <button
+                              type="button"
+                              onClick={() => handleSaveTask(task.id)}
+                              disabled={savingTask}
+                              className="rounded-md bg-blue-600 px-3 py-1 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-70"
+                            >
+                              {savingTask ? 'Saving...' : 'Save'}
+                            </button>
+                            <button
+                              type="button"
+                              onClick={handleCancelEditTask}
+                              disabled={savingTask}
+                              className="rounded-md border border-gray-300 bg-white px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-70"
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                          {editTaskError ? (
+                            <p className="text-sm text-red-600">
+                              {editTaskError}
+                            </p>
+                          ) : null}
+                        </div>
+                      ) : (
+                        <>
+                          <span
+                            className={`h-3 w-3 rounded-full ${
+                              task.is_complete ? 'bg-green-500' : 'bg-gray-300'
+                            }`}
+                          />
+                          <span
+                            className={
+                              task.is_complete
+                                ? 'text-gray-500 line-through'
+                                : 'text-gray-900'
+                            }
+                          >
+                            {task.title}
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() => handleEditTask(task)}
+                            disabled={savingTask}
+                            className="ml-auto text-sm font-medium text-blue-600 hover:underline disabled:cursor-not-allowed disabled:opacity-60"
+                            aria-label={`Edit task ${task.title}`}
+                          >
+                            Edit
+                          </button>
+                        </>
+                      )}
                     </li>
                   ))}
                 </ul>

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useCallback, useEffect, useState } from 'react';
 import Header from '../components/Header';
 import { Link } from 'react-router-dom';
 import { ApiRequestError, projectsApi } from '../api/client';
@@ -8,13 +8,13 @@ import { useLogout } from '../hooks/useLogout';
 export default function Projects() {
   const { logout } = useLogout();
   const userEmail = localStorage.getItem('user_email');
-  const handleAuthError = (err: unknown) => {
+  const handleAuthError = useCallback((err: unknown) => {
     if (err instanceof ApiRequestError && (err.status === 401 || err.status === 403)) {
       logout();
       return true;
     }
     return false;
-  };
+  }, [logout]);
   const [projects, setProjects] = useState<ProjectData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -47,7 +47,7 @@ export default function Projects() {
     return () => {
       active = false;
     };
-  }, []);
+  }, [handleAuthError]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();


### PR DESCRIPTION
Add task update endpoint and TaskUpdate schema with validation
Add frontend inline edit UI (save/cancel) and tasksApi.update
Expand backend/frontend tests for update flow and error cases
Stabilize projects page loading by memoizing logout handler
